### PR TITLE
Add a genesis delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,5 +34,6 @@ Options:
 - `--output` (string): The directory where the chain data and artifacts are stored. It defaults to `local-testnet`.
 - `--continue` (bool): Whether to restart the chain from a previous run if the output folder is not empty. It defaults to `false`.
 - `--use-bin-path` (bool): Whether to use the binaries from the local path instead of downloading them. It defaults to `false`.
+- `--genesis-delay` (int): The delay in seconds before the genesis block is created. It is used to account for the delay between the creation of the artifacts and the running of the services. It defaults to `5` seconds.
 
 Unless the `--continue` flag is set, the playground will delete the output directory and start a new chain from scratch on every run.

--- a/main.go
+++ b/main.go
@@ -48,6 +48,7 @@ var outputFlag string
 var continueFlag bool
 var useBinPathFlag bool
 var validateFlag bool
+var genesisDelayFlag uint64
 
 var rootCmd = &cobra.Command{
 	Use:   "playground",
@@ -151,6 +152,8 @@ func main() {
 	rootCmd.Flags().StringVar(&outputFlag, "output", "local-testnet", "")
 	rootCmd.Flags().BoolVar(&continueFlag, "continue", false, "")
 	rootCmd.Flags().BoolVar(&useBinPathFlag, "use-bin-path", false, "")
+	rootCmd.Flags().Uint64Var(&genesisDelayFlag, "genesis-delay", 5, "")
+
 	downloadArtifactsCmd.Flags().BoolVar(&validateFlag, "validate", false, "")
 	validateCmd.Flags().Uint64Var(&numBlocksValidate, "num-blocks", 5, "")
 
@@ -219,7 +222,7 @@ func setupArtifacts() error {
 		return err
 	}
 
-	genesisTime := uint64(time.Now().Unix())
+	genesisTime := uint64(time.Now().Add(time.Duration(genesisDelayFlag) * time.Second).Unix())
 	config := params.BeaconConfig()
 
 	gen := interop.GethTestnetGenesis(genesisTime, config)


### PR DESCRIPTION
This PR adds a genesis delay to give time to the node services to be online.