### PR TITLE
Add default output folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To stop the playground, press `Ctrl+C`.
 
 Options:
 
-- `--output` (string): The directory where the chain data and artifacts are stored. It defaults to `$HOME/.playground/testnet`.
+- `--output` (string): The directory where the chain data and artifacts are stored. It defaults to `$HOME/.playground/devnet`.
 - `--continue` (bool): Whether to restart the chain from a previous run if the output folder is not empty. It defaults to `false`.
 - `--use-bin-path` (bool): Whether to use the binaries from the local path instead of downloading them. It defaults to `false`.
 - `--genesis-delay` (int): The delay in seconds before the genesis block is created. It is used to account for the delay between the creation of the artifacts and the running of the services. It defaults to `5` seconds.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To stop the playground, press `Ctrl+C`.
 
 Options:
 
-- `--output` (string): The directory where the chain data and artifacts are stored. It defaults to `local-testnet`.
+- `--output` (string): The directory where the chain data and artifacts are stored. It defaults to `$HOME/.playground/testnet`.
 - `--continue` (bool): Whether to restart the chain from a previous run if the output folder is not empty. It defaults to `false`.
 - `--use-bin-path` (bool): Whether to use the binaries from the local path instead of downloading them. It defaults to `false`.
 - `--genesis-delay` (int): The delay in seconds before the genesis block is created. It is used to account for the delay between the creation of the artifacts and the running of the services. It defaults to `5` seconds.

--- a/main.go
+++ b/main.go
@@ -149,7 +149,7 @@ var validateCmd = &cobra.Command{
 }
 
 func main() {
-	rootCmd.Flags().StringVar(&outputFlag, "output", "local-testnet", "")
+	rootCmd.Flags().StringVar(&outputFlag, "output", "", "")
 	rootCmd.Flags().BoolVar(&continueFlag, "continue", false, "")
 	rootCmd.Flags().BoolVar(&useBinPathFlag, "use-bin-path", false, "")
 	rootCmd.Flags().Uint64Var(&genesisDelayFlag, "genesis-delay", 5, "")
@@ -166,6 +166,16 @@ func main() {
 }
 
 func runIt() error {
+	if outputFlag == "" {
+		// Use the $HOMEDIR/testnet as the default output
+		homeDir, err := getHomeDir()
+		if err != nil {
+			return err
+		}
+		outputFlag = filepath.Join(homeDir, "testnet")
+	}
+
+	fmt.Printf("Output directory: %s\n", outputFlag)
 	out := &output{dst: outputFlag}
 
 	exists := out.Exists("data_reth")
@@ -753,4 +763,21 @@ var prefundedAccounts = []string{
 	"0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356",
 	"0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97",
 	"0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6",
+}
+
+func getHomeDir() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("error getting user home directory: %w", err)
+	}
+
+	// Define the path for our custom home directory
+	customHomeDir := filepath.Join(homeDir, ".playground")
+
+	// Create output directory if it doesn't exist
+	if err := os.MkdirAll(customHomeDir, 0755); err != nil {
+		return "", fmt.Errorf("error creating output directory: %v", err)
+	}
+
+	return customHomeDir, nil
 }

--- a/main.go
+++ b/main.go
@@ -167,12 +167,12 @@ func main() {
 
 func runIt() error {
 	if outputFlag == "" {
-		// Use the $HOMEDIR/testnet as the default output
+		// Use the $HOMEDIR/devnet as the default output
 		homeDir, err := getHomeDir()
 		if err != nil {
 			return err
 		}
-		outputFlag = filepath.Join(homeDir, "testnet")
+		outputFlag = filepath.Join(homeDir, "devnet")
 	}
 
 	fmt.Printf("Output directory: %s\n", outputFlag)


### PR DESCRIPTION
By default, if the `output` flag is not set, the artifacts and chain data are stored in $HOME/.playground/devnet.