### PR TITLE
Add flag to watch for proposer builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,5 +35,6 @@ Options:
 - `--continue` (bool): Whether to restart the chain from a previous run if the output folder is not empty. It defaults to `false`.
 - `--use-bin-path` (bool): Whether to use the binaries from the local path instead of downloading them. It defaults to `false`.
 - `--genesis-delay` (int): The delay in seconds before the genesis block is created. It is used to account for the delay between the creation of the artifacts and the running of the services. It defaults to `5` seconds.
+- `--watch-payloads` (bool): If enabled, it logs whenever a builder builds a valid block through the relay. It defaults to `false`.
 
 Unless the `--continue` flag is set, the playground will delete the output directory and start a new chain from scratch on every run.


### PR DESCRIPTION
This PR adds a new `watch-payloads` to track whenever a builder builds a block through the relayer.