### PR TITLE
Enable rpc on reth and determinsitic p2p key

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ The playground performs the following steps:
 
 To stop the playground, press `Ctrl+C`.
 
+The `EL` instance is deployed with this deterministic enode address:
+
+```
+enode://3479db4d9217fb5d7a8ed4d61ac36e120b05d36c2eefb795dc42ff2e971f251a2315f5649ea1833271e020b9adc98d5db9973c7ed92d6b2f1f2223088c3d852f@127.0.0.1:8545
+```
+
 Options:
 
 - `--output` (string): The directory where the chain data and artifacts are stored. It defaults to `$HOME/.playground/devnet`.


### PR DESCRIPTION
This PR enables the p2p interface of the `Reth` node locally (it does not connect to any external networks) and uses a deterministic private key to generate the enode address.