### PR TITLE
Watch payloads by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ Options:
 - `--continue` (bool): Whether to restart the chain from a previous run if the output folder is not empty. It defaults to `false`.
 - `--use-bin-path` (bool): Whether to use the binaries from the local path instead of downloading them. It defaults to `false`.
 - `--genesis-delay` (int): The delay in seconds before the genesis block is created. It is used to account for the delay between the creation of the artifacts and the running of the services. It defaults to `5` seconds.
-- `--watch-payloads` (bool): If enabled, it logs whenever a builder builds a valid block through the relay. It defaults to `false`.
 - `--electra`: (bool): If enabled, it enables the Electra fork at startup. It defaults to `false`.
 
 Unless the `--continue` flag is set, the playground will delete the output directory and start a new chain from scratch on every run.

--- a/main.go
+++ b/main.go
@@ -59,7 +59,6 @@ var continueFlag bool
 var useBinPathFlag bool
 var validateFlag bool
 var genesisDelayFlag uint64
-var watchPayloadsFlag bool
 var latestForkFlag bool
 var useRethForValidation bool
 var secondaryBuilderPort uint64
@@ -167,7 +166,6 @@ func main() {
 	rootCmd.Flags().BoolVar(&continueFlag, "continue", false, "")
 	rootCmd.Flags().BoolVar(&useBinPathFlag, "use-bin-path", false, "")
 	rootCmd.Flags().Uint64Var(&genesisDelayFlag, "genesis-delay", 5, "")
-	rootCmd.Flags().BoolVar(&watchPayloadsFlag, "watch-payloads", false, "")
 	rootCmd.Flags().BoolVar(&latestForkFlag, "electra", false, "")
 	rootCmd.Flags().BoolVar(&useRethForValidation, "use-reth-for-validation", false, "enable flashbots_validateBuilderSubmissionV* on reth and use them for validation")
 	rootCmd.Flags().Uint64Var(&secondaryBuilderPort, "secondary", 1234, "port to use for the secondary builder")
@@ -225,9 +223,7 @@ func runIt() error {
 		return err
 	}
 
-	if watchPayloadsFlag {
-		go watchProposerPayloads()
-	}
+	go watchProposerPayloads()
 
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, os.Interrupt)


### PR DESCRIPTION
This PR enables watch payloads by default on the playground.