### PR TITLE
fix(pectra): Support ELECTRA_FORK_VERSION in mev-boost-relay

### DIFF
--- a/mev-boost-relay/mev-boost-relay.go
+++ b/mev-boost-relay/mev-boost-relay.go
@@ -212,6 +212,7 @@ func generateEthNetworkDetails(spec *Spec, info *beaconclient.GetGenesisResponse
 		"BELLATRIX_FORK_VERSION":  spec.BellatrixForkVersion,
 		"CAPELLA_FORK_VERSION":    spec.CapellaForkVersion,
 		"DENEB_FORK_VERSION":      spec.DenebForkVersion,
+		"ELECTRA_FORK_VERSION":    spec.ElectraForkVersion,
 	}
 	for k, v := range envs {
 		if err := os.Setenv(k, v); err != nil {
@@ -430,6 +431,7 @@ type Spec struct {
 	BellatrixForkVersion            string `json:"BELLATRIX_FORK_VERSION"`             //nolint:tagliatelle
 	CapellaForkVersion              string `json:"CAPELLA_FORK_VERSION"`               //nolint:tagliatelle
 	DenebForkVersion                string `json:"DENEB_FORK_VERSION"`                 //nolint:tagliatelle
+	ElectraForkVersion              string `json:"ELECTRA_FORK_VERSION"`               //nolint:tagliatelle
 }
 
 func getSpec(beaconURL string) (*Spec, error) {


### PR DESCRIPTION
Note that to fully work this still requires the other changes from #32 but this change is stand-alone and doesn't require us to use unstable versions so seems worth merging separately.