### PR TITLE
fix(mev-boost-relay): rbuilder now requires a relay that supports cancellations.

### DIFF
--- a/main.go
+++ b/main.go
@@ -469,7 +469,8 @@ func setupServices(svcManager *serviceManager, out *output) error {
 			// "--disable-discovery",
 			// http config
 			"--http",
-			"--http.api", "admin,eth,net,web3",
+			// enable flashbots and mev for local testing
+			"--http.api", "admin,eth,net,web3,net,rpc,flashbots,mev",
 			"--http.port", "8545",
 			"--authrpc.port", "8551",
 			"--authrpc.jwtsecret", "{{.Dir}}/jwtsecret",
@@ -477,9 +478,6 @@ func setupServices(svcManager *serviceManager, out *output) error {
 			"--engine.persistence-threshold", "0", "--engine.memory-block-buffer-target", "0",
 			"-vvvv",
 		).
-		If(useRethForValidation, func(s *service) *service {
-			return s.WithReplacementArgs("--http.api", "admin,eth,web3,net,rpc,flashbots")
-		}).
 		WithPort("rpc", 30303).
 		WithPort("http", 8545).
 		WithPort("authrpc", 8551).

--- a/mev-boost-relay/mev-boost-relay.go
+++ b/mev-boost-relay/mev-boost-relay.go
@@ -156,6 +156,11 @@ func New(config *Config) (*MevBoostRelay, error) {
 		return nil, fmt.Errorf("incorrect builder API secret key provided")
 	}
 
+	// rbuilder now requires the relay to support bundle cancellations
+	if err := os.Setenv("ENABLE_BUILDER_CANCELLATIONS", "1"); err != nil {
+		return nil, fmt.Errorf("failed to set ENABLE_BUILDER_CANCELLATIONS: %w", err)
+	}
+
 	apiOpts := api.RelayAPIOpts{
 		Log:             log.WithField("service", "api"),
 		ListenAddr:      fmt.Sprintf("%s:%d", config.ApiListenAddr, config.ApiListenPort),


### PR DESCRIPTION
Newer versions of rbuilder as of https://github.com/flashbots/rbuilder/pull/401 requires the relay to have cancellations enabled.

AFAICT this is only available on mev-boost-relay via setting the `ENABLE_BUILDER_CANCELLATIONS` env var.

Also, now that we are on reth 1.2.0+ we can always enable the `flashbots` and `mev` namespaces in `--http.api`.