### PR TITLE
Override better

### DIFF
--- a/internal/manifest.go
+++ b/internal/manifest.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"strings"
-	"sync"
 	"text/template"
 	"time"
 
@@ -100,7 +99,6 @@ type ServiceWatchdog interface {
 }
 
 func RunWatchdog(manifest *Manifest) error {
-	var wg sync.WaitGroup
 	watchdogErr := make(chan error, len(manifest.Services()))
 
 	output, err := manifest.out.LogOutput("watchdog")
@@ -110,23 +108,16 @@ func RunWatchdog(manifest *Manifest) error {
 
 	for _, s := range manifest.Services() {
 		if watchdogFn, ok := s.component.(ServiceWatchdog); ok {
-			wg.Add(1)
-
 			go func() {
-				defer wg.Done()
 				if err := watchdogFn.Watchdog(output, s, context.Background()); err != nil {
 					watchdogErr <- fmt.Errorf("service %s watchdog failed: %w", s.Name, err)
 				}
 			}()
 		}
 	}
-	wg.Wait()
 
-	close(watchdogErr)
-	for err := range watchdogErr {
-		if err != nil {
-			return err
-		}
+	if err := <-watchdogErr; err != nil {
+		return fmt.Errorf("failed to run watchdog: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes a few things with the override:
- You can override now also docker images for services.
- Validates that the override is applied to a service in the manifest.
- Validates that if the override is a docker image, the image exists (not tested).