### PR TITLE
Run block builder internal with rollup-boost

### DIFF
--- a/examples/op-stack-rollup-boost.md
+++ b/examples/op-stack-rollup-boost.md
@@ -45,3 +45,11 @@ The command above starts op-reth as an external block builder with the following
 - `--trusted-peers`: Connects to our Op Stack's EL node using the deterministic enode address
 
 Once op-reth is running, it will connect to the Op Stack and begin participating in block building. You can verify it's working by checking the logs of both the sequencer and op-reth for successful block proposals.
+
+## Internal block builder
+
+To use an internal `op-reth` as a block builder, run:
+
+```
+$ go run main.go cook opstack --external-builder op-reth
+```

--- a/internal/recipe_opstack.go
+++ b/internal/recipe_opstack.go
@@ -47,13 +47,21 @@ func (o *OpRecipe) Apply(ctx *ExContext, artifacts *Artifacts) *Manifest {
 		BeaconNode: "beacon",
 	})
 
+	externalBuilderRef := o.externalBuilder
+	if o.externalBuilder == "op-reth" {
+		// Add a new op-reth service and connect it to Rollup-boost
+		svcManager.AddService("op-reth", &OpReth{})
+
+		externalBuilderRef = Connect("op-reth", "authrpc")
+	}
+
 	elNode := "op-geth"
 	if o.externalBuilder != "" {
 		elNode = "rollup-boost"
 
 		svcManager.AddService("rollup-boost", &RollupBoost{
 			ELNode:  "op-geth",
-			Builder: o.externalBuilder,
+			Builder: externalBuilderRef,
 		})
 	}
 	svcManager.AddService("op-node", &OpNode{


### PR DESCRIPTION
Before, the only way to run an external block builder with rollup-boost was with a builder running on the host machine. Now, if you set `--extenra-builder=op-reth`, builder-playground will run op-reth as the external builder in Docker.