### PR TITLE
Mm builderhub mock proxy

### DIFF
--- a/internal/components.go
+++ b/internal/components.go
@@ -251,7 +251,7 @@ func (r *RethEL) Run(svc *service, ctx *ExContext) {
 			"--datadir", "{{.Dir}}/data_reth",
 			"--color", "never",
 			"--ipcpath", "{{.Dir}}/reth.ipc",
-			"--addr", "127.0.0.1",
+			"--addr", "0.0.0.0",
 			"--port", `{{Port "rpc" 30303}}`,
 			// "--disable-discovery",
 			// http config
@@ -301,7 +301,7 @@ func (l *LighthouseBeaconNode) Run(svc *service, ctx *ExContext) {
 			"--enable-private-discovery",
 			"--disable-peer-scoring",
 			"--staking",
-			"--enr-address", "127.0.0.1",
+			"--enr-address", "10.0.2.2",
 			"--enr-udp-port", `{{Port "p2p" 9000}}`,
 			"--enr-tcp-port", `{{Port "p2p" 9000}}`,
 			"--enr-quic-port", `{{Port "quic-p2p" 9100}}`,

--- a/internal/components.go
+++ b/internal/components.go
@@ -435,8 +435,8 @@ type BuilderHubPostgres struct {
 func (b *BuilderHubPostgres) Run(service *service, ctx *ExContext) {
 	service.
 		WithImage("docker.io/flashbots/builder-hub-db").
-		WithTag("latest").
-		WithPort("postgres", 5432).
+		WithTag("0.2.1").
+		WithLocalPort("postgres", 5432).
 		WithEnv("POSTGRES_USER", "postgres").
 		WithEnv("POSTGRES_PASSWORD", "postgres").
 		WithEnv("POSTGRES_DB", "postgres").
@@ -460,7 +460,7 @@ type BuilderHub struct {
 func (b *BuilderHub) Run(service *service, ctx *ExContext) {
 	service.
 		WithImage("docker.io/flashbots/builder-hub").
-		WithTag("latest").
+		WithTag("0.2.1").
 		WithEntrypoint("/app/builder-hub").
 		WithEnv("POSTGRES_DSN", "postgres://postgres:postgres@"+ConnectRaw(b.postgres, "postgres", "")+"/postgres?sslmode=disable").
 		WithEnv("LISTEN_ADDR", "0.0.0.0:"+`{{Port "http" 8080}}`).
@@ -483,7 +483,7 @@ func (b *BuilderHubMockProxy) Run(service *service, ctx *ExContext) {
 	service.
 		WithImage("nginx").
 		WithTag("1.27").
-		WithPort("http", 8888).
+		WithLocalPort("http", 8888).
 		DependsOnRunning(b.TargetService).
 		WithEntrypoint("/bin/sh").
 		WithArgs("-c", fmt.Sprintf(`cat > /etc/nginx/conf.d/default.conf << 'EOF'

--- a/internal/local_runner.go
+++ b/internal/local_runner.go
@@ -583,7 +583,13 @@ func (d *LocalRunner) toDockerComposeService(s *service) (map[string]interface{}
 	if len(s.ports) > 0 {
 		ports := []string{}
 		for _, p := range s.ports {
-			ports = append(ports, fmt.Sprintf("%d:%d", p.HostPort, p.Port))
+			if p.Local {
+				// Bind only to localhost (127.0.0.1)
+				ports = append(ports, fmt.Sprintf("127.0.0.1:%d:%d", p.HostPort, p.Port))
+			} else {
+				// Bind to all interfaces (default)
+				ports = append(ports, fmt.Sprintf("%d:%d", p.HostPort, p.Port))
+			}
 		}
 		service["ports"] = ports
 	}

--- a/internal/recipe_buildernet.go
+++ b/internal/recipe_buildernet.go
@@ -52,12 +52,10 @@ func (b *BuilderNetRecipe) Apply(ctx *ExContext, artifacts *Artifacts) *Manifest
 		postgres: "builder-hub-postgres",
 	})
 
-	// Optionally add mock proxy for testing
-	if b.includeMockProxy {
-		svcManager.AddService("builder-hub-proxy", &BuilderHubMockProxy{
-			TargetService: "builder-hub",
-		})
-	}
+	// Add mock proxy for testing
+	svcManager.AddService("builder-hub-proxy", &BuilderHubMockProxy{
+		TargetService: "builder-hub",
+	})
 
 	return svcManager
 }


### PR DESCRIPTION
This PR adds the following:
- Local port binding for security purposes and disallow exposing any ports external, such as the attack attempt on the postgres container being exposed externally with poor authentication.
- Switched from latest version for the builder-hub and its db containers to a stable version to avoid potential conflicts
- Using own custom nginx mock proxy instead of the builder-hub-mock-proxy due to hardcoded configuration in the original container image
- Changed the address of reth to 0.0.0.0 instead of 127.0.0.1 to expose it for the qemu VM image to allow peering
- Changed the enr-address of lighthouse beacon node to 10.0.2.2 which is qemu's default gateway address for the host. This way, the host would broadcast itself to the peers over the same network that the buildernet qemu VM image accesses