### PR TITLE
fix: set an authrpc address for the opstack

### DIFF
--- a/examples/op-stack-rollup-boost.md
+++ b/examples/op-stack-rollup-boost.md
@@ -2,7 +2,7 @@
 
 This example shows how to deploy an Op Stack with rollup-boost with an external block builder (op-reth).
 
-First, download the op-reth binary:
+First, download the `op-reth` binary:
 
 ```bash
 $ go run main.go artifacts op-reth
@@ -35,7 +35,10 @@ The `--external-builder` flag is used to specify the URL of the external block b
 Third, we can start the `op-reth` binary as the external block builder:
 
 ```bash
-$ $HOME/.playground/op-reth-v1.3.12 node --http --http.port 2222 --authrpc.port 4444 --authrpc.jwtsecret $HOME/.playground/devnet/jwtsecret --chain $HOME/.playground/devnet/l2-genesis.json --datadir /tmp/builder --disable-discovery --port 30333 --trusted-peers enode://3479db4d9217fb5d7a8ed4d61ac36e120b05d36c2eefb795dc42ff2e971f251a2315f5649ea1833271e020b9adc98d5db9973c7ed92d6b2f1f2223088c3d852f@127.0.0.1:30304
+$ $HOME/.playground/op-reth-v1.3.12 node --http --http.port 2222 \
+    --authrpc.addr 0.0.0.0 --authrpc.port 4444 --authrpc.jwtsecret $HOME/.playground/devnet/jwtsecret \
+    --chain $HOME/.playground/devnet/l2-genesis.json --datadir /tmp/builder --disable-discovery --port 30333 \
+    --trusted-peers enode://3479db4d9217fb5d7a8ed4d61ac36e120b05d36c2eefb795dc42ff2e971f251a2315f5649ea1833271e020b9adc98d5db9973c7ed92d6b2f1f2223088c3d852f@127.0.0.1:30304
 ```
 
 The command above starts op-reth as an external block builder with the following key parameters:
@@ -44,7 +47,7 @@ The command above starts op-reth as an external block builder with the following
 - `--authrpc.jwtsecret`: Uses the JWT secret generated during Op Stack deployment
 - `--trusted-peers`: Connects to our Op Stack's EL node using the deterministic enode address
 
-Once op-reth is running, it will connect to the Op Stack and begin participating in block building. You can verify it's working by checking the logs of both the sequencer and op-reth for successful block proposals.
+Once `op-reth` is running, it will connect to the Op Stack and begin participating in block building. You can verify it's working by checking the logs of both the sequencer and op-reth for successful block proposals.
 
 ## Internal block builder
 


### PR DESCRIPTION
The following changes have been made:

- Added the `--authrpc.add 0.0.0.0` parameter, since Docker creates a virtual network interface with a different IP (which is the one added to the *сompose* file)
- Split the `op-reth` launch command (as a builder) into parts for better readability  
- Minor update – the `op-reth` binary was highlighted using formatting