### PR TITLE
chore: fix mev-boost container with multi beacon nodes

### DIFF
--- a/internal/components.go
+++ b/internal/components.go
@@ -396,6 +396,7 @@ func (m *MevBoostRelay) Run(service *service, ctx *ExContext) {
 	service.
 		WithImage("docker.io/flashbots/playground-utils").
 		WithTag("latest").
+		WithEnv("ALLOW_SYNCING_BEACON_NODE", "1").
 		WithEntrypoint("mev-boost-relay").
 		DependsOnHealthy(m.BeaconClient).
 		WithArgs(


### PR DESCRIPTION
This PR fixes the issue #108 when running beacon nodes with more than 0 target-peers

Fixes #108 