### PR TITLE
feat: namespaced output dir

### DIFF
--- a/internal/artifacts.go
+++ b/internal/artifacts.go
@@ -76,7 +76,7 @@ func NewArtifactsBuilder() *ArtifactsBuilder {
 		applyLatestL1Fork: false,
 		genesisDelay:      MinimumGenesisDelay,
 		OpblockTime:       defaultOpBlockTimeSeconds,
-		networkName:       "ethplayground",
+		networkName:       DefaultNetworkName,
 	}
 }
 

--- a/internal/artifacts.go
+++ b/internal/artifacts.go
@@ -66,6 +66,7 @@ type ArtifactsBuilder struct {
 	applyLatestL1Fork bool
 	genesisDelay      uint64
 	applyLatestL2Fork *uint64
+	networkName       string
 }
 
 func NewArtifactsBuilder() *ArtifactsBuilder {
@@ -73,6 +74,7 @@ func NewArtifactsBuilder() *ArtifactsBuilder {
 		outputDir:         "",
 		applyLatestL1Fork: false,
 		genesisDelay:      MinimumGenesisDelay,
+		networkName:       "ethplayground",
 	}
 }
 
@@ -96,6 +98,11 @@ func (b *ArtifactsBuilder) GenesisDelay(genesisDelaySeconds uint64) *ArtifactsBu
 	return b
 }
 
+func (b *ArtifactsBuilder) NetworkName(networkName string) *ArtifactsBuilder {
+	b.networkName = networkName
+	return b
+}
+
 type Artifacts struct {
 	Out *output
 }
@@ -106,9 +113,15 @@ func (b *ArtifactsBuilder) Build() (*Artifacts, error) {
 		return nil, err
 	}
 	if b.outputDir == "" {
-		// Use the $HOMEDIR/devnet as the default output
-		b.outputDir = filepath.Join(homeDir, "devnet")
+		// If a custom network name is specified, namespace the folder as devnet-[networkname].
+		if b.networkName != "" && b.networkName != DefaultNetworkName {
+			b.outputDir = filepath.Join(homeDir, fmt.Sprintf("devnet-%s", b.networkName))
+		} else {
+			// Use $HOMEDIR/devnet as the default output.
+			b.outputDir = filepath.Join(homeDir, "devnet")
+		}
 	}
+	log.Printf("using output directory: %s", b.outputDir)
 
 	out := &output{dst: b.outputDir, homeDir: homeDir}
 

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -1,0 +1,3 @@
+package internal
+
+const DefaultNetworkName = "ethplayground"

--- a/internal/local_runner.go
+++ b/internal/local_runner.go
@@ -25,8 +25,6 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-const defaultNetworkName = "ethplayground"
-
 // LocalRunner is a component that runs the services from the manifest on the local host machine.
 // By default, it uses docker and docker compose to run all the services.
 // But, some services (if they are configured to do so) can be run on the host machine instead.
@@ -146,7 +144,7 @@ func NewLocalRunner(out *output, manifest *Manifest, overrides map[string]string
 	}
 
 	if networkName == "" {
-		networkName = defaultNetworkName
+		networkName = DefaultNetworkName
 	}
 	d := &LocalRunner{
 		out:                  out,

--- a/main.go
+++ b/main.go
@@ -211,7 +211,7 @@ func runIt(recipe internal.Recipe) error {
 	}
 
 	builder := recipe.Artifacts()
-	builder.OutputDir(outputFlag)
+	builder.OutputDir(outputFlag).NetworkName(networkName)
 	builder.GenesisDelay(genesisDelayFlag)
 	artifacts, err := builder.Build()
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -211,7 +211,8 @@ func runIt(recipe internal.Recipe) error {
 	}
 
 	builder := recipe.Artifacts()
-	builder.OutputDir(outputFlag).NetworkName(networkName)
+	builder.OutputDir(outputFlag)
+	builder.NetworkName(networkName)
 	builder.GenesisDelay(genesisDelayFlag)
 	artifacts, err := builder.Build()
 	if err != nil {


### PR DESCRIPTION
**Problem**
When running multiple playground instances without specifying --output, both defaulted to $HOME/.playground/devnet, causing one instance to overwrite the other's files and break running containers.

**Solution**
When **--output** is not set and a custom **--network** is specified (different from **ethplayground**), the output folder is now automatically namespaced as devnet-[network].

If **--network** is not set or equals ethplayground, output remains devnet to not upset existing downstream users.