### PR TITLE
Add Kubernetes manifest generator

### DIFF
--- a/examples/BuilderPlayground-CRD-Definition.yml
+++ b/examples/BuilderPlayground-CRD-Definition.yml
@@ -1,0 +1,241 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: builderplaygrounddeployments.playground.flashbots.io
+spec:
+  group: playground.flashbots.io
+  names:
+    kind: BuilderPlaygroundDeployment
+    plural: builderplaygrounddeployments
+    singular: builderplaygrounddeployment
+    shortNames:
+      - bpd
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          required:
+            - spec
+          properties:
+            spec:
+              type: object
+              required:
+                - services
+              properties:
+                # Recipe/origin information
+                recipe:
+                  type: string
+                  description: "The recipe used to generate this deployment (e.g., l1, opstack)"
+                
+                # Storage configuration for the deployment
+                storage:
+                  type: object
+                  description: "Storage configuration for the deployment"
+                  properties:
+                    type:
+                      type: string
+                      enum: [local-path, pvc]
+                      description: "Storage type (local-path for development, pvc for cluster deployments)"
+                    path:
+                      type: string
+                      description: "Path on host for local-path storage"
+                    storageClass:
+                      type: string
+                      description: "StorageClass to use for PVC (if type is pvc)"
+                    size:
+                      type: string
+                      description: "Size of storage (if type is pvc)"
+                
+                # Network configuration
+                network:
+                  type: object
+                  description: "Network configuration"
+                  properties:
+                    name:
+                      type: string
+                      description: "Network name, similar to docker-compose network"
+                
+                # Service definitions
+                services:
+                  type: array
+                  description: "List of services in this deployment"
+                  items:
+                    type: object
+                    required:
+                      - name
+                      - image
+                    properties:
+                      name:
+                        type: string
+                        description: "Service name"
+                      
+                      image:
+                        type: string
+                        description: "Container image for the service"
+                      
+                      tag:
+                        type: string
+                        description: "Image tag"
+                      
+                      entrypoint:
+                        type: array
+                        description: "Container entrypoint command"
+                        items:
+                          type: string
+                      
+                      args:
+                        type: array
+                        description: "Container command arguments"
+                        items:
+                          type: string
+                      
+                      env:
+                        type: object
+                        description: "Environment variables"
+                        additionalProperties:
+                          type: string
+                      
+                      ports:
+                        type: array
+                        description: "Ports exposed by the service"
+                        items:
+                          type: object
+                          required:
+                            - name
+                            - port
+                          properties:
+                            name:
+                              type: string
+                              description: "Port name"
+                            port:
+                              type: integer
+                              description: "Container port"
+                            protocol:
+                              type: string
+                              enum: [tcp, udp]
+                              default: tcp
+                              description: "Port protocol"
+                            hostPort:
+                              type: integer
+                              description: "Port on host machine (if applicable)"
+                      
+                      dependencies:
+                        type: array
+                        description: "Service dependencies"
+                        items:
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            name:
+                              type: string
+                              description: "Name of the dependent service"
+                            condition:
+                              type: string
+                              enum: [running, healthy]
+                              default: running
+                              description: "Condition for dependency"
+                      
+                      readyCheck:
+                        type: object
+                        description: "Service readiness check"
+                        properties:
+                          queryURL:
+                            type: string
+                            description: "URL to query for readiness"
+                          test:
+                            type: array
+                            items:
+                              type: string
+                            description: "Command to run for readiness test"
+                          interval:
+                            type: string
+                            description: "Interval between readiness checks"
+                          timeout:
+                            type: string
+                            description: "Timeout for readiness checks"
+                          retries:
+                            type: integer
+                            description: "Number of retries for readiness checks"
+                          startPeriod:
+                            type: string
+                            description: "Initial delay before starting readiness checks"
+                      
+                      labels:
+                        type: object
+                        description: "Service labels"
+                        additionalProperties:
+                          type: string
+                      
+                      useHostExecution:
+                        type: boolean
+                        description: "Whether to run the service on the host instead of in k8s"
+                        default: false
+                      
+                      volumes:
+                        type: array
+                        description: "Volume mounts for the service"
+                        items:
+                          type: object
+                          required:
+                            - name
+                            - mountPath
+                          properties:
+                            name:
+                              type: string
+                              description: "Volume name"
+                            mountPath:
+                              type: string
+                              description: "Path in container to mount volume"
+                            subPath:
+                              type: string
+                              description: "Sub-path within the volume to mount"
+                
+              # Status section for the operator to update
+            status:
+              type: object
+              properties:
+                phase:
+                  type: string
+                  description: "Deployment phase (Pending, Running, Failed, etc.)"
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                serviceStatuses:
+                  type: object
+                  additionalProperties:
+                    type: object
+                    properties:
+                      ready:
+                        type: boolean
+                      status:
+                        type: string
+                      logs:
+                        type: string
+                        description: "Path to service logs"
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Status
+          type: string
+          jsonPath: .status.phase
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp

--- a/internal/k8s_generator.go
+++ b/internal/k8s_generator.go
@@ -1,0 +1,397 @@
+package internal
+
+import (
+    "fmt"
+    "os"
+    "path/filepath"
+    
+    "gopkg.in/yaml.v2"
+)
+
+// K8sGenerator handles creation of Kubernetes manifests
+type K8sGenerator struct {
+    Manifest    *Manifest
+    RecipeName  string
+    StorageType string
+    StoragePath string
+    StorageClass string
+    StorageSize  string
+    NetworkName  string
+    OutputDir    string
+}
+
+// NewK8sGenerator creates a new Kubernetes manifest generator
+func NewK8sGenerator(manifest *Manifest, recipeName string, outputDir string) *K8sGenerator {
+    return &K8sGenerator{
+        Manifest:    manifest,
+        RecipeName:  recipeName,
+        StorageType: "local-path",
+        StoragePath: "/data/builder-playground",
+        StorageClass: "standard",
+        StorageSize:  "10Gi",
+        OutputDir:    outputDir,
+    }
+}
+
+// Generate creates a Kubernetes manifest and writes it to disk
+func (g *K8sGenerator) Generate() error {
+    // Generate the CRD
+    crd, err := g.buildCRD()
+    if err != nil {
+        return fmt.Errorf("failed to build CRD: %w", err)
+    }
+    
+    // Marshal to YAML
+    yamlData, err := yaml.Marshal(crd)
+    if err != nil {
+        return fmt.Errorf("failed to marshal CRD to YAML: %w", err)
+    }
+    
+    // Write to file
+    outputPath := filepath.Join(g.OutputDir, "k8s-manifest.yaml")
+    if err := os.WriteFile(outputPath, yamlData, 0644); err != nil {
+        return fmt.Errorf("failed to write manifest to %s: %w", outputPath, err)
+    }
+    
+    return nil
+}
+
+// BuilderPlaygroundDeployment represents the top-level K8s CRD
+type BuilderPlaygroundDeployment struct {
+    // APIVersion is the Kubernetes API version for this resource
+    APIVersion string `yaml:"apiVersion"`
+    // Kind identifies this as a BuilderPlaygroundDeployment
+    Kind string `yaml:"kind"`
+    // Metadata contains the resource metadata
+    Metadata BuilderPlaygroundMetadata `yaml:"metadata"`
+    // Spec defines the desired state of the deployment
+    Spec BuilderPlaygroundSpec `yaml:"spec"`
+}
+
+// BuilderPlaygroundMetadata contains the resource metadata
+type BuilderPlaygroundMetadata struct {
+    // Name is the name of the deployment
+    Name string `yaml:"name"`
+}
+
+// BuilderPlaygroundSpec defines the desired state of the deployment
+type BuilderPlaygroundSpec struct {
+    // Recipe is the builder-playground recipe used (l1, opstack, etc)
+    Recipe string `yaml:"recipe"`
+    // Storage defines how persistent data should be stored
+    Storage BuilderPlaygroundStorage `yaml:"storage"`
+    // Network defines networking configuration (optional)
+    Network *BuilderPlaygroundNetwork `yaml:"network,omitempty"`
+    // Services is the list of services in this deployment
+    Services []BuilderPlaygroundService `yaml:"services"`
+}
+
+// BuilderPlaygroundStorage defines storage configuration
+type BuilderPlaygroundStorage struct {
+    // Type is the storage type, either "local-path" or "pvc"
+    Type string `yaml:"type"`
+    // Path is the host path for local-path storage (used when type is "local-path")
+    Path string `yaml:"path,omitempty"`
+    // StorageClass is the K8s storage class (used when type is "pvc")
+    StorageClass string `yaml:"storageClass,omitempty"`
+    // Size is the storage size (used when type is "pvc")
+    Size string `yaml:"size,omitempty"`
+}
+
+// BuilderPlaygroundNetwork defines network configuration
+type BuilderPlaygroundNetwork struct {
+    // Name is the name of the network
+    Name string `yaml:"name"`
+}
+
+// BuilderPlaygroundService represents a single service in the deployment
+type BuilderPlaygroundService struct {
+    // Name is the service name
+    Name string `yaml:"name"`
+    // Image is the container image
+    Image string `yaml:"image"`
+    // Tag is the container image tag
+    Tag string `yaml:"tag"`
+    // Entrypoint overrides the container entrypoint
+    Entrypoint []string `yaml:"entrypoint,omitempty"`
+    // Args are the container command arguments
+    Args []string `yaml:"args,omitempty"`
+    // Env defines environment variables
+    Env map[string]string `yaml:"env,omitempty"`
+    // Ports are the container ports to expose
+    Ports []BuilderPlaygroundPort `yaml:"ports,omitempty"`
+    // Dependencies defines services this service depends on
+    Dependencies []BuilderPlaygroundDependency `yaml:"dependencies,omitempty"`
+    // ReadyCheck defines how to determine service readiness
+    ReadyCheck *BuilderPlaygroundReadyCheck `yaml:"readyCheck,omitempty"`
+    // Labels are the service labels
+    Labels map[string]string `yaml:"labels,omitempty"`
+    // UseHostExecution indicates whether to run on host instead of in container
+    UseHostExecution bool `yaml:"useHostExecution,omitempty"`
+    // Volumes are the volume mounts for the service
+    Volumes []BuilderPlaygroundVolume `yaml:"volumes,omitempty"`
+}
+
+// BuilderPlaygroundPort represents a port configuration
+type BuilderPlaygroundPort struct {
+    // Name is a unique identifier for this port
+    Name string `yaml:"name"`
+    // Port is the container port number
+    Port int `yaml:"port"`
+    // Protocol is either "tcp" or "udp"
+    Protocol string `yaml:"protocol,omitempty"`
+    // HostPort is the port to expose on the host (if applicable)
+    HostPort int `yaml:"hostPort,omitempty"`
+}
+
+// BuilderPlaygroundDependency represents a service dependency
+type BuilderPlaygroundDependency struct {
+    // Name is the name of the dependent service
+    Name string `yaml:"name"`
+    // Condition is either "running" or "healthy"
+    Condition string `yaml:"condition"`
+}
+
+// BuilderPlaygroundReadyCheck defines readiness checking
+type BuilderPlaygroundReadyCheck struct {
+    // QueryURL is the URL to query for readiness
+    QueryURL string `yaml:"queryURL,omitempty"`
+    // Test is the command to run for readiness check
+    Test []string `yaml:"test,omitempty"`
+    // Interval is the time between checks
+    Interval string `yaml:"interval,omitempty"`
+    // Timeout is the maximum time for a check
+    Timeout string `yaml:"timeout,omitempty"`
+    // Retries is the number of retry attempts
+    Retries int `yaml:"retries,omitempty"`
+    // StartPeriod is the initial delay before checks begin
+    StartPeriod string `yaml:"startPeriod,omitempty"`
+}
+
+// BuilderPlaygroundVolume represents a volume mount
+type BuilderPlaygroundVolume struct {
+    // Name is the volume name
+    Name string `yaml:"name"`
+    // MountPath is the path in the container
+    MountPath string `yaml:"mountPath"`
+    // SubPath is the path within the volume (optional)
+    SubPath string `yaml:"subPath,omitempty"`
+}
+
+// buildCRD creates the CRD structure
+func (g *K8sGenerator) buildCRD() (BuilderPlaygroundDeployment, error) {
+    crd := BuilderPlaygroundDeployment{
+        APIVersion: "playground.flashbots.io/v1alpha1",
+        Kind:       "BuilderPlaygroundDeployment",
+        Metadata: BuilderPlaygroundMetadata{
+            Name: "builder-playground-" + g.RecipeName,
+        },
+        Spec: BuilderPlaygroundSpec{
+            Recipe: g.RecipeName,
+            Storage: BuilderPlaygroundStorage{
+                Type: g.StorageType,
+            },
+            Services: []BuilderPlaygroundService{},
+        },
+    }
+
+    // Configure storage based on type
+    if g.StorageType == "local-path" {
+        crd.Spec.Storage.Path = g.StoragePath
+    } else if g.StorageType == "pvc" {
+        crd.Spec.Storage.StorageClass = g.StorageClass
+        crd.Spec.Storage.Size = g.StorageSize
+    }
+    
+    // Add network configuration if available
+    if g.NetworkName != "" {
+        crd.Spec.Network = &BuilderPlaygroundNetwork{
+            Name: g.NetworkName,
+        }
+    }
+    
+    // Convert services
+    for _, svc := range g.Manifest.Services() {
+        k8sService, err := convertServiceToK8s(svc)
+        if err != nil {
+            return crd, fmt.Errorf("failed to convert service %s: %w", svc.Name, err)
+        }
+        crd.Spec.Services = append(crd.Spec.Services, k8sService)
+    }
+    
+    return crd, nil
+}
+
+// Define internal labels that should be filtered out
+var internalLabels = map[string]bool{
+    "service":            true,
+    "playground":         true,
+    "playground.session": true,
+}
+
+// convertServiceToK8s converts a service to Kubernetes representation
+func convertServiceToK8s(svc *service) (BuilderPlaygroundService, error) {
+    // Validate required fields
+    if svc.image == "" {
+        return BuilderPlaygroundService{}, fmt.Errorf("service %s missing required image", svc.Name)
+    }
+    
+    k8sService := BuilderPlaygroundService{
+        Name:  svc.Name,
+        Image: svc.image,
+        Tag:   svc.tag,
+    }
+    
+    // Convert entrypoint
+    if svc.entrypoint != "" {
+        k8sService.Entrypoint = []string{svc.entrypoint}
+    }
+    
+    // Convert args
+    if len(svc.args) > 0 {
+        k8sService.Args = svc.args
+    }
+    
+    // Convert env variables
+    if len(svc.env) > 0 {
+        k8sService.Env = make(map[string]string)
+        for k, v := range svc.env {
+            k8sService.Env[k] = v
+        }
+    }
+    
+    // Convert ports
+    if len(svc.ports) > 0 {
+        k8sPorts := make([]BuilderPlaygroundPort, 0, len(svc.ports))
+        for _, port := range svc.ports {
+            k8sPort := BuilderPlaygroundPort{
+                Name:     port.Name,
+                Port:     port.Port,
+                Protocol: port.Protocol,
+            }
+            if port.HostPort != 0 {
+                k8sPort.HostPort = port.HostPort
+            }
+            k8sPorts = append(k8sPorts, k8sPort)
+        }
+        k8sService.Ports = k8sPorts
+    }
+    
+    // Convert dependencies
+    if len(svc.dependsOn) > 0 {
+        k8sDeps := make([]BuilderPlaygroundDependency, 0, len(svc.dependsOn))
+        for _, dep := range svc.dependsOn {
+            condition := "running"
+            if dep.Condition == DependsOnConditionHealthy {
+                condition = "healthy"
+            }
+            
+            k8sDep := BuilderPlaygroundDependency{
+                Name:      dep.Name,
+                Condition: condition,
+            }
+            k8sDeps = append(k8sDeps, k8sDep)
+        }
+        k8sService.Dependencies = k8sDeps
+    }
+    
+    // Convert readiness check
+    if svc.readyCheck != nil {
+        k8sReadyCheck := &BuilderPlaygroundReadyCheck{}
+        
+        if svc.readyCheck.QueryURL != "" {
+            k8sReadyCheck.QueryURL = svc.readyCheck.QueryURL
+        }
+        
+        if len(svc.readyCheck.Test) > 0 {
+            k8sReadyCheck.Test = svc.readyCheck.Test
+        }
+        
+        if svc.readyCheck.Interval != 0 {
+            k8sReadyCheck.Interval = svc.readyCheck.Interval.String()
+        }
+        
+        if svc.readyCheck.Timeout != 0 {
+            k8sReadyCheck.Timeout = svc.readyCheck.Timeout.String()
+        }
+        
+        if svc.readyCheck.Retries != 0 {
+            k8sReadyCheck.Retries = svc.readyCheck.Retries
+        }
+        
+        if svc.readyCheck.StartPeriod != 0 {
+            k8sReadyCheck.StartPeriod = svc.readyCheck.StartPeriod.String()
+        }
+        
+        // Only add the ready check if at least one field is set
+        if k8sReadyCheck.QueryURL != "" || len(k8sReadyCheck.Test) > 0 {
+            k8sService.ReadyCheck = k8sReadyCheck
+        }
+    }
+    
+    // Convert labels
+    if len(svc.labels) > 0 {
+        serviceLabels := make(map[string]string)
+        
+        for k, v := range svc.labels {
+            // Skip internal labels
+            if !internalLabels[k] {
+                serviceLabels[k] = v
+            }
+        }
+        
+        // Check for use-host-execution
+        if useHost, ok := svc.labels["use-host-execution"]; ok && useHost == "true" {
+            k8sService.UseHostExecution = true
+        }
+        
+        if len(serviceLabels) > 0 {
+            k8sService.Labels = serviceLabels
+        }
+    }
+    
+    // Add standard artifacts volume
+    k8sService.Volumes = []BuilderPlaygroundVolume{
+        {
+            Name:      "artifacts",
+            MountPath: "/artifacts",
+        },
+    }
+    
+    return k8sService, nil
+}
+
+// GenerateK8sManifest creates a Kubernetes manifest from a builder-playground manifest
+// This is the main entry point for integration with the codebase
+func GenerateK8sManifest(manifest *Manifest, recipeName string, output *output, storageType string, storageParams map[string]string) error {
+    // Get absolute output directory path
+    outputDir, err := output.AbsoluteDstPath()
+    if err != nil {
+        return fmt.Errorf("failed to get absolute output directory path: %w", err)
+    }
+    
+    generator := NewK8sGenerator(manifest, recipeName, outputDir)
+    
+    // Configure storage settings
+    generator.StorageType = storageType
+    
+    if storageType == "local-path" {
+        if path, ok := storageParams["path"]; ok {
+            generator.StoragePath = path
+        }
+    } else if storageType == "pvc" {
+        if class, ok := storageParams["class"]; ok {
+            generator.StorageClass = class
+        }
+        if size, ok := storageParams["size"]; ok {
+            generator.StorageSize = size
+        }
+    }
+    
+    // Set network name if provided
+    if netName, ok := storageParams["network"]; ok {
+        generator.NetworkName = netName
+    }
+    
+    return generator.Generate()
+}


### PR DESCRIPTION
# Builder Playground Kubernetes Integration
## Design Analysis and Implementation Report

This report summarizes our discussions, design analysis, and implementation approach for enabling Kubernetes support in builder-playground. It serves as a comprehensive guide to continue development of the Kubernetes operator.

## 1. Context and Background

Builder Playground is a tool to deploy end-to-end environments for blockchain builder testing. Currently, it uses Docker Compose for local deployments, but there's a need to support Kubernetes for more scalable and production-ready deployments.

### Current Architecture Overview

Builder Playground follows a clear architecture:
- **Recipes**: Define environments to deploy (L1, OpStack, BuilderNet)
- **Artifacts**: Files and configurations needed by services
- **Manifest**: Intermediate representation of services and their relationships
- **Runner**: Responsible for executing the manifest (currently Docker Compose)

### Integration Goals

1. Enable Kubernetes deployment option for builder-playground
2. Maintain the simple developer experience
3. Support both local development and testing/staging environments
4. Allow for customization before deployment
5. Provide a path toward a Kubernetes operator

## 2. Design Approaches Considered

We analyzed two primary approaches for Kubernetes integration:

### Approach 1: K8s Runner Implementation

This approach would add a new runner to the existing architecture:

```go
// Register the kubernetes runner
factory.Register("kubernetes", func(out *output, manifest *Manifest, overrides map[string]string, interactive bool) (Runner, error) {
    namespace := "default"
    if ns, ok := overrides["namespace"]; ok {
        namespace = ns
        delete(overrides, "namespace")
    }
    return NewK8sRunner(out, manifest, namespace)
})
```

**Pros**:
- Tightly integrated with builder-playground
- Extends existing architecture
- Full control over resource lifecycle
- Easier debugging (single process)

**Cons**:
- Less Kubernetes-native
- More complex logic to track resource status
- Places burden of k8s resource management on CLI
- More complex error handling

### Approach 2: Kubernetes Operator

This approach creates a dedicated Kubernetes operator that watches for custom resources describing a Builder Playground deployment:

```yaml
apiVersion: playground.flashbots.io/v1alpha1
kind: BuilderPlayground
metadata:
  name: demo-builder
spec:
  latestFork: true
  genesisDelay: 30
  dryRun: false
  storageMethod: local-path
  # other configuration...
```

**Pros**:
- More Kubernetes-native (follows best practices)
- Better scalability for future features
- Cleaner separation of concerns
- Better for production deployments

**Cons**:
- More complex implementation (requires operator)
- Requires managing two codebases
- Debugging may be more difficult across system boundaries
- Higher learning curve for contributors

### Hybrid Approach (Selected)

After careful analysis, we chose a hybrid approach, focusing on:

1. Creating a manifest generator that outputs Kubernetes CRDs
2. Designing a CRD structure that preserves the builder-playground service model
3. Setting the stage for a future operator implementation

This approach enables users to:
- Generate Kubernetes manifests with `--k8s` flag
- Optionally inspect and modify the manifests
- Apply them to Kubernetes with standard tools
- Eventually use a purpose-built operator for enhanced functionality

## 3. CRD Design

We designed a comprehensive CRD structure that captures all aspects of the builder-playground manifest:

```yaml
apiVersion: playground.flashbots.io/v1alpha1
kind: BuilderPlaygroundDeployment
metadata:
  name: l1-environment
spec:
  # Recipe information
  recipe: l1
  
  # Storage configuration
  storage:
    type: local-path
    path: /data/builder-playground
  
  # Services configuration
  services:
    - name: beacon
      image: sigp/lighthouse
      tag: v7.0.0-beta.0
      entrypoint: ["lighthouse"]
      args:
        - "bn"
        - "--datadir"
        - "{{.Dir}}/data_beacon_node"
        # ...more args
      ports:
        - name: http
          containerPort: 3500
      dependencies:
        - name: el
          condition: healthy
```

Key design decisions:

1. **Self-Contained Definition**: All services are contained within a single CRD, similar to how docker-compose works, making the resource easier to understand and manage.

2. **Template Preservation**: The manifest preserves templating expressions like `{{.Dir}}` and `{{Service "el" "authrpc"}}` to be resolved by the operator.

3. **Service Relationships**: Dependencies between services are explicitly defined, allowing the operator to manage deployment order.

4. **Storage Abstraction**: Two storage options (local-path for development, PVC for production) provide flexibility for different environments.

5. **No Status Field**: The status field is omitted from the generated CRD as it should be managed by the Kubernetes controller.

## 4. Implementation Details

### Integration Approach

The implementation adds a `--k8s` flag to the existing `cook` command that triggers generation of a Kubernetes manifest alongside the regular artifacts:

```bash
$ playground cook l1 --dry-run --k8s --output ./output --storage-type local-path
```

### Key Components

1. **K8sGenerator** struct:
```go
type K8sGenerator struct {
    Manifest     *Manifest
    RecipeName   string
    StorageType  string
    StoragePath  string
    StorageClass string
    StorageSize  string
    NetworkName  string
    OutputDir    string
}
```

2. **Strongly Typed CRD Structures**:
```go
type BuilderPlaygroundDeployment struct {
    APIVersion string                    `yaml:"apiVersion"`
    Kind       string                    `yaml:"kind"`
    Metadata   BuilderPlaygroundMetadata `yaml:"metadata"`
    Spec       BuilderPlaygroundSpec     `yaml:"spec"`
}
```

3. **Service Conversion Logic**:
```go
func convertServiceToK8s(svc *service) (BuilderPlaygroundService, error) {
    // Validate required fields
    if svc.image == "" {
        return BuilderPlaygroundService{}, fmt.Errorf("service %s missing required image", svc.Name)
    }
    
    k8sService := BuilderPlaygroundService{
        Name:  svc.Name,
        Image: svc.image,
        Tag:   svc.tag,
    }
    
    // Convert other fields...
    
    return k8sService, nil
}
```

4. **Label Filtering with Map**:
```go
var internalLabels = map[string]bool{
    "service":            true,
    "playground":         true,
    "playground.session": true,
}

for k, v := range labels {
    if !internalLabels[k] {
        serviceLabels[k] = v
    }
}
```

### Error Handling

The implementation includes proper validation and error handling:

```go
// Validate required fields
if svc.image == "" {
    return BuilderPlaygroundService{}, fmt.Errorf("service %s missing required image", svc.Name)
}

// Propagate errors with context
k8sService, err := convertServiceToK8s(svc)
if err != nil {
    return crd, fmt.Errorf("failed to convert service %s: %w", svc.Name, err)
}
```

## 5. Current Limitations and Future Development

### Current Limitations

Our current CRD implementation doesn't yet address several important aspects:

1. **Host Execution**: There's currently no concrete solution for running services on the host machine when deploying to Kubernetes. The CRD includes a `useHostExecution` flag, but implementing this in Kubernetes requires careful consideration. Possible approaches include:
   - Using DaemonSets with privileged containers
   - Running services outside of Kubernetes with network exposure
   - Using tools like Kubevirt for virtualization

2. **Complex Networking**: The current design doesn't fully address complex networking scenarios like exposing specific ports to external clients or handling cross-service communication with specific protocols.

3. **Resource Limits**: The CRD doesn't yet include configurations for CPU/memory limits and requests.

4. **Security Considerations**: JWT tokens and other sensitive information aren't properly handled through Kubernetes secrets yet.

5. **Node Affinity and Placement**: For testing/staging deployments, node selection and affinity rules would be needed.

### Decision to Prioritize Core Functionality

We've deliberately chosen to focus first on covering the core functionality:
- Service definitions and relationships
- Storage configuration
- Basic networking
- Service dependencies

This approach allows us to get a working implementation more quickly, with a plan to address the more complex aspects in future iterations. The current implementation provides a solid foundation that captures the essential structure of builder-playground environments, while leaving room for enhancements.

## 6. Operator Implementation Guidelines

For developing the Kubernetes operator that will consume these CRDs, consider the following key aspects in the context of our single-pod approach:

### 1. Template Resolution in Single-Pod Context

Template resolution becomes more straightforward in a single-pod architecture:

| Template | Single-Pod Resolution |
|----------|----------------------|
| `{{.Dir}}` | Common volume mount path (e.g., `/artifacts`) |
| `{{Service "el" "authrpc"}}` | `localhost:8551` (direct container-to-container communication) |
| `{{Port "http" 8545}}` | The actual port number as defined in the container |

This simplifies the implementation as services can use localhost networking rather than requiring Kubernetes DNS for service discovery.

### 2. Resource Creation Strategy

Given our single-pod approach, the operator should create:

- **One Pod with Multiple Containers**: Each service becomes a container within the same pod
- **Services**: For network access to exposed ports
- **ConfigMap/Secret**: For shared configuration files
- **SinglePVC**: For persistent storage (based on storage configuration)

This simplifies resource management compared to a multi-pod approach while maintaining the relationship structure between services.

### 3. Dependency Management

With the single-pod approach, dependency management becomes primarily an initialization concern:

- **Init Containers**: Can be used to ensure services start in the correct order
- **Readiness Probes**: Services can wait for dependencies to be ready
- **Shared Volume**: All containers have access to the same storage, simplifying file-based dependencies

This is simpler than managing dependencies across multiple independent deployments, as all containers are guaranteed to run on the same node and can communicate directly.

### 4. Readiness Checks

Transform the readyCheck definitions into Kubernetes readiness probes:

```yaml
# From CRD
readyCheck:
  queryURL: http://localhost:3500/eth/v1/node/syncing
  interval: 1s
  timeout: 30s

# To Kubernetes
readinessProbe:
  httpGet:
    path: /eth/v1/node/syncing
    port: 3500
  periodSeconds: 1
  timeoutSeconds: 30
```

### 5. Storage Implementation

With the single-pod approach, storage becomes simpler:

- **Single Shared Volume**: All containers in the pod mount the same volume
- **Common Access Path**: Each container can access the same files at the same path
- **Storage Options**:
  - `local-path`: Use hostPath volumes for development environments
  - `pvc`: Use a single PersistentVolumeClaim with ReadWriteOnce access mode for production

This eliminates the need for ReadWriteMany storage classes that would be required in a multi-pod architecture.

### 7. Host Execution in Single-Pod Context

For services with `useHostExecution: true`, the single-pod approach presents challenges:

- **Container vs. Host**: By definition, these services need to run outside the pod
- **Potential Solutions**:
  - A coordinating controller that runs some services as pods and others as external processes
  - A hybrid deployment where the operator manages both Kubernetes resources and external processes
  - Using a privileged container with access to the host's process namespace

This remains one of the more challenging aspects to solve and may require further architectural discussions.

## 7. Testing Recommendations

When testing the operator, focus on:

1. **Local Development Environments**:
   - Test with minikube, k3s, and kind
   - Verify all services start in the correct order
   - Check template resolution works correctly

2. **Recipe Compatibility**:
   - Test all recipes (l1, opstack, buildernet)
   - Verify service interactions work as expected

3. **Storage Options**:
   - Test local-path for development environments
   - Test PVC for testing/staging environments

4. **Template Processing**:
   - Test resolution of all template expressions
   - Verify service discovery works correctly

## 7. Conclusion and Next Steps

The implemented Kubernetes manifest generator provides a solid foundation for building a complete Kubernetes operator for Builder Playground. By generating CRDs that preserve all the necessary information about services and their relationships, we enable a clear path forward for Kubernetes integration.

### Current Focus: Matching the Docker Compose Workflow

It's important to emphasize that our current goal is to match the existing workflow with `--dry-run` and docker-compose.yml, not to build a fully automated deployment system yet. The current approach allows users to:

1. Generate Kubernetes manifests
2. Inspect and potentially modify them
3. Manually deploy to Kubernetes when ready

This matches the developer workflow already familiar to builder-playground users, where the dry-run enables inspection and customization before deployment.

### Future Deployment Options

For the longer term, we've considered two main approaches for the operator deployment:

1. **Standalone Operator**: Deploy the operator separately, then submit BuilderPlayground manifests. The operator would deploy a one-shot builder-playground container that generates the final service manifests for the operator to apply.

2. **Integrated Operator**: Include the operator code directly in the builder-playground binary, with an option to run it as the operator itself. This would create a more integrated solution but add complexity to the codebase.

Either approach would eventually enable a more automated workflow, but they are intentionally not part of the current implementation.

### Next Steps

1. **Develop Operator Skeleton**:
   - Register the CRD type
   - Create basic controller structure
   - Define reconciliation logic

2. **Implement Template Handling**:
   - Create a template processor for builder-playground templates
   - Test with different service configurations

3. **Resource Management**:
   - Implement single pod with multiple containers
   - Use init containers for proper ordering
   - Manage shared PVC for storage

4. **Testing**:
   - Begin with simple recipes and progressively test more complex ones
   - Verify all features work as with docker-compose

This hybrid approach maintains the simplicity of builder-playground while enabling Kubernetes deployment, providing a flexible solution that supports both development and production use cases, with a clear path for evolution toward more automated deployment in the future.
