### PR TITLE
Use custom protocol and user for Connections

### DIFF
--- a/internal/artifacts.go
+++ b/internal/artifacts.go
@@ -405,12 +405,12 @@ func getPrivKey(privStr string) (*ecdsa.PrivateKey, error) {
 	return priv, nil
 }
 
-func ConnectRaw(service, port, protocol string) string {
-	return fmt.Sprintf(`{{Service "%s" "%s" "%s"}}`, service, port, protocol)
+func ConnectRaw(service, port, protocol, user string) string {
+	return fmt.Sprintf(`{{Service "%s" "%s" "%s" "%s"}}`, service, port, protocol, user)
 }
 
 func Connect(service, port string) string {
-	return ConnectRaw(service, port, "http")
+	return ConnectRaw(service, port, "http", "")
 }
 
 type output struct {

--- a/internal/components.go
+++ b/internal/components.go
@@ -485,7 +485,7 @@ func (b *BuilderHub) Run(service *Service, ctx *ExContext) {
 		WithImage("docker.io/flashbots/builder-hub").
 		WithTag("latest").
 		WithEntrypoint("/app/builder-hub").
-		WithEnv("POSTGRES_DSN", "postgres://postgres:postgres@"+ConnectRaw(b.postgres, "postgres", "")+"/postgres?sslmode=disable").
+		WithEnv("POSTGRES_DSN", ConnectRaw(b.postgres, "postgres", "postgres", "postgres:postgres")+"/postgres?sslmode=disable").
 		WithEnv("LISTEN_ADDR", "0.0.0.0:"+`{{Port "http" 8080}}`).
 		WithEnv("ADMIN_ADDR", "0.0.0.0:"+`{{Port "admin" 8081}}`).
 		WithEnv("INTERNAL_ADDR", "0.0.0.0:"+`{{Port "internal" 8082}}`).

--- a/internal/manifest.go
+++ b/internal/manifest.go
@@ -206,6 +206,8 @@ type Port struct {
 type NodeRef struct {
 	Service   string
 	PortLabel string
+	Protocol  string
+	User      string
 }
 
 // serviceLogs is a service to access the logs of the running service
@@ -443,7 +445,7 @@ func applyTemplate(templateStr string) (string, []Port, []NodeRef) {
 	// ther can be multiple port and nodere because in the case of op-geth we pass a whole string as nested command args
 
 	funcs := template.FuncMap{
-		"Service": func(name string, portLabel, protocol string) string {
+		"Service": func(name string, portLabel, protocol, user string) string {
 			if name == "" {
 				panic("BUG: service name cannot be empty")
 			}
@@ -455,8 +457,8 @@ func applyTemplate(templateStr string) (string, []Port, []NodeRef) {
 			// here we only keep the references to the services to be checked if they are valid and an be resolved
 			// later on for the runtime we will do the resolve stage.
 			// TODO: this will get easier when we move away from templates and use interface and structs.
-			nodeRef = append(nodeRef, NodeRef{Service: name, PortLabel: portLabel})
-			return fmt.Sprintf(`{{Service "%s" "%s"}}`, name, portLabel)
+			nodeRef = append(nodeRef, NodeRef{Service: name, PortLabel: portLabel, Protocol: protocol, User: user})
+			return fmt.Sprintf(`{{Service "%s" "%s" "%s" "%s"}}`, name, portLabel, protocol, user)
 		},
 		"Port": func(name string, defaultPort int) string {
 			portRef = append(portRef, Port{Name: name, Port: defaultPort, Protocol: ProtocolTCP})

--- a/internal/manifest_test.go
+++ b/internal/manifest_test.go
@@ -1,0 +1,58 @@
+package internal
+
+import (
+	"testing"
+)
+
+func TestNodeRefString(t *testing.T) {
+	var testCases = []struct {
+		protocol string
+		service  string
+		port     int
+		user     string
+		expected string
+	}{
+		{
+			protocol: "",
+			service:  "test",
+			port:     80,
+			user:     "",
+			expected: "test:80",
+		},
+		{
+			protocol: "",
+			service:  "test",
+			port:     80,
+			user:     "test",
+			expected: "test@test:test",
+		},
+		{
+			protocol: "http",
+			service:  "test",
+			port:     80,
+			user:     "",
+			expected: "http://test:80",
+		},
+		{
+			protocol: "http",
+			service:  "test",
+			port:     80,
+			user:     "test",
+			expected: "http://test@test:test",
+		},
+		{
+			protocol: "enode",
+			service:  "test",
+			port:     80,
+			user:     "",
+			expected: "enode://test:80",
+		},
+	}
+
+	for _, testCase := range testCases {
+		result := printAddr(testCase.protocol, testCase.service, testCase.port, testCase.user)
+		if result != testCase.expected {
+			t.Errorf("expected %s, got %s", testCase.expected, result)
+		}
+	}
+}


### PR DESCRIPTION
This PR introduces the concept of "protocol" and "user" for the connections that the components define. Before, we could only define either http or tcp connections. This will allow to use the "Service" primitive to link up nodes on the P2P layer.