### PR TITLE
Add Bootnode component (Part 2)

### DIFF
--- a/playground/catalog.go
+++ b/playground/catalog.go
@@ -23,6 +23,7 @@ func init() {
 	register(&nullService{})
 	register(&OpRbuilder{})
 	register(&FlashblocksRPC{})
+	register(&Bootnode{})
 }
 
 func FindComponent(name string) ServiceGen {

--- a/playground/components.go
+++ b/playground/components.go
@@ -77,7 +77,7 @@ func (o *OpRbuilder) Run(service *Service, ctx *ExContext) {
 		WithVolume("data", "/data_op_reth")
 
 	if ctx.Bootnode != nil {
-		service.WithArgs("--trusted-peers", ctx.Bootnode.Connect())
+		service.WithArgs("--bootnodes", ctx.Bootnode.Connect())
 	}
 
 	if o.Flashblocks {
@@ -123,7 +123,7 @@ func (f *FlashblocksRPC) Run(service *Service, ctx *ExContext) {
 
 	if ctx.Bootnode != nil {
 		service.WithArgs(
-			"--trusted-peers", ctx.Bootnode.Connect(),
+			"--bootnodes", ctx.Bootnode.Connect(),
 		)
 	}
 }

--- a/playground/recipe_opstack.go
+++ b/playground/recipe_opstack.go
@@ -70,12 +70,12 @@ func (o *OpRecipe) Apply(ctx *ExContext, artifacts *Artifacts) *Manifest {
 	flashblocksBuilderURLRef := o.flashblocksBuilderURL
 	externalBuilderRef := o.externalBuilder
 
-	opGeth := &OpGeth{}
-	svcManager.AddService("op-geth", opGeth)
+	bootnode := &Bootnode{}
+	svcManager.AddService("bootnode", bootnode)
 
 	ctx.Bootnode = &BootnodeRef{
-		Service: "op-geth",
-		ID:      opGeth.Enode.NodeID(),
+		Service: "bootnode",
+		ID:      bootnode.Enode.NodeID(),
 	}
 
 	if o.externalBuilder == "op-reth" {
@@ -113,6 +113,7 @@ func (o *OpRecipe) Apply(ctx *ExContext, artifacts *Artifacts) *Manifest {
 		})
 	}
 
+	svcManager.AddService("op-geth", &OpGeth{})
 	svcManager.AddService("op-node", &OpNode{
 		L1Node:   "el",
 		L1Beacon: "beacon",


### PR DESCRIPTION
This is a follow up for #147. It adds a custom `bootnode` component.

Not working yet, the recipe gets deployed but the nodes cannot find each other.