### PR TITLE
run contender

### DIFF
--- a/playground/catalog.go
+++ b/playground/catalog.go
@@ -24,6 +24,7 @@ func init() {
 	register(&nullService{})
 	register(&OpRbuilder{})
 	register(&FlashblocksRPC{})
+	register(&Contender{})
 }
 
 func FindComponent(name string) ServiceGen {

--- a/playground/components.go
+++ b/playground/components.go
@@ -717,3 +717,23 @@ func (n *nullService) Run(service *Service, ctx *ExContext) {
 func (n *nullService) Name() string {
 	return "null"
 }
+
+type Contender struct{}
+
+func (c *Contender) Name() string {
+	return "contender"
+}
+
+func (c *Contender) Run(service *Service, ctx *ExContext) {
+	args := []string{
+		"spam",
+		"-l", // loop indefinitely
+		"--min-balance", "10 ether",
+		"-r", Connect("el", "http"),
+		"--tpb", "20", // send 20 txs per block
+	}
+	service.WithImage("flashbots/contender").
+		WithTag("latest").
+		WithArgs(args...).
+		DependsOnHealthy("beacon")
+}

--- a/playground/recipe_buildernet.go
+++ b/playground/recipe_buildernet.go
@@ -59,6 +59,8 @@ func (b *BuilderNetRecipe) Apply(ctx *ExContext, artifacts *Artifacts) *Manifest
 		})
 	}
 
+	svcManager.AddService("contender", &Contender{})
+
 	return svcManager
 }
 

--- a/playground/recipe_l1.go
+++ b/playground/recipe_l1.go
@@ -106,6 +106,9 @@ func (l *L1Recipe) Apply(ctx *ExContext, artifacts *Artifacts) *Manifest {
 			ValidationServer: mevBoostValidationServer,
 		})
 	}
+
+	svcManager.AddService("contender", &Contender{})
+
 	return svcManager
 }
 

--- a/playground/recipe_opstack.go
+++ b/playground/recipe_opstack.go
@@ -126,6 +126,9 @@ func (o *OpRecipe) Apply(ctx *ExContext, artifacts *Artifacts) *Manifest {
 		RollupNode:         "op-node",
 		MaxChannelDuration: o.batcherMaxChannelDuration,
 	})
+
+	svcManager.AddService("contender", &Contender{})
+
 	return svcManager
 }
 


### PR DESCRIPTION
adds contender as a component and runs it with default settings (which run `fill-block`) once the beacon node reports as healthy

## questions

- do we want to support L2 spamming, too?
- should we support multiple contender scenarios, or is the default (`fill-block`) fine?