### PR TITLE
feat: add privileged flag, allow adding absolute path for volume

### DIFF
--- a/playground/local_runner.go
+++ b/playground/local_runner.go
@@ -648,11 +648,16 @@ func (d *LocalRunner) toDockerComposeService(s *Service) (map[string]interface{}
 
 	// create the bind volumes
 	for localPath, volumeName := range s.VolumesMapped {
-		volumeDirAbsPath, err := d.createVolume(s.Name, volumeName)
-		if err != nil {
-			return nil, err
+		// If the volume name is an absolute path, use it directly
+		if filepath.IsAbs(volumeName) {
+			volumes[volumeName] = localPath
+		} else {
+			volumeDirAbsPath, err := d.createVolume(s.Name, volumeName)
+			if err != nil {
+				return nil, err
+			}
+			volumes[volumeDirAbsPath] = localPath
 		}
-		volumes[volumeDirAbsPath] = localPath
 	}
 
 	volumesInLine := []string{}
@@ -669,6 +674,10 @@ func (d *LocalRunner) toDockerComposeService(s *Service) (map[string]interface{}
 		// Add the ethereum network
 		"networks": []string{d.networkName},
 		"labels":   labels,
+	}
+
+	if s.Privileged {
+		service["privileged"] = true
 	}
 
 	if d.platform != "" {

--- a/playground/manifest.go
+++ b/playground/manifest.go
@@ -279,6 +279,7 @@ type Service struct {
 	Tag        string `json:"tag,omitempty"`
 	Image      string `json:"image,omitempty"`
 	Entrypoint string `json:"entrypoint,omitempty"`
+	Privileged bool   `json:"privileged,omitempty"`
 }
 
 type instance struct {
@@ -409,11 +410,30 @@ func (s *Service) WithArgs(args ...string) *Service {
 	return s
 }
 
+func (s *Service) WithPrivileged() *Service {
+	s.Privileged = true
+	return s
+}
+
 func (s *Service) WithVolume(name string, localPath string) *Service {
 	if s.VolumesMapped == nil {
 		s.VolumesMapped = make(map[string]string)
 	}
 	s.VolumesMapped[localPath] = name
+	return s
+}
+
+// WithAbsoluteVolume adds a volume mapping using an absolute path on the host.
+// This is useful for binding system paths like /var/run/docker.sock.
+// The path must be absolute and will be used as-is without any modification.
+func (s *Service) WithAbsoluteVolume(containerPath string, hostPath string) *Service {
+	if !filepath.IsAbs(hostPath) {
+		panic(fmt.Sprintf("host path must be absolute: %s", hostPath))
+	}
+	if s.VolumesMapped == nil {
+		s.VolumesMapped = make(map[string]string)
+	}
+	s.VolumesMapped[containerPath] = hostPath
 	return s
 }
 


### PR DESCRIPTION
This PR exposes the privileged flag to be set for services. Additionally, we added a way to mount absolute paths from the filesystem to any service, which is useful if you want to bind `/var/run/docker.sock`


Note: At phylax systems, we used the builder-playground to generate our demo environment for OP-Talos. 
During our work we made a small set of changes which are worth suggesting as upstream contributions.
I tried to split the work in several PRs, to let the maintainers decide what is worth to be included.

