### PR TITLE
refactor: use maps.Copy for cleaner map handling

### DIFF
--- a/playground/artifacts.go
+++ b/playground/artifacts.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"maps"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -201,9 +202,7 @@ func (b *ArtifactsBuilder) Build() (*Artifacts, error) {
 		if err := json.Unmarshal(contents, &alloc); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal opState: %w", err)
 		}
-		for addr, account := range alloc {
-			gen.Alloc[addr] = account
-		}
+		maps.Copy(gen.Alloc, alloc)
 	}
 
 	block := gen.ToBlock()

--- a/playground/local_runner.go
+++ b/playground/local_runner.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"maps"
 	"net"
 	"os"
 	"os/exec"
@@ -134,9 +135,7 @@ func NewLocalRunner(cfg *RunnerConfig) (*LocalRunner, error) {
 	if cfg.Overrides == nil {
 		cfg.Overrides = make(map[string]string)
 	}
-	for k, v := range cfg.Manifest.overrides {
-		cfg.Overrides[k] = v
-	}
+	maps.Copy(cfg.Overrides, cfg.Manifest.overrides)
 
 	// Create the concrete instances to run
 	instances := []*instance{}
@@ -627,9 +626,7 @@ func (d *LocalRunner) toDockerComposeService(s *Service) (map[string]interface{}
 	}
 
 	// apply the user defined labels
-	for k, v := range d.labels {
-		labels[k] = v
-	}
+	maps.Copy(labels, d.labels)
 
 	// add the local ports exposed by the service as labels
 	// we have to do this for now since we do not store the manifest in JSON yet.


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/maps@go1.21.1#Copy) added in the go1.21 standard library, which can make the code more concise and easy to read.