### PR TITLE
add --contender.arg flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ var labels playground.MapStringFlag
 var disableLogs bool
 var platform string
 var contenderEnabled bool
-var contenderTps uint64
+var contenderArgs []string
 
 var rootCmd = &cobra.Command{
 	Use:   "playground",
@@ -182,7 +182,7 @@ func main() {
 		recipeCmd.Flags().BoolVar(&disableLogs, "disable-logs", false, "disable logs")
 		recipeCmd.Flags().StringVar(&platform, "platform", "", "docker platform to use")
 		recipeCmd.Flags().BoolVar(&contenderEnabled, "contender", false, "spam nodes with contender")
-		recipeCmd.Flags().Uint64Var(&contenderTps, "contender.tps", 20, "txs/sec to send from contender")
+		recipeCmd.Flags().StringArrayVar(&contenderArgs, "contender.arg", []string{}, "add/override contender CLI flags")
 
 		cookCmd.AddCommand(recipeCmd)
 	}
@@ -232,8 +232,8 @@ func runIt(recipe playground.Recipe) error {
 	svcManager := recipe.Apply(&playground.ExContext{
 		LogLevel: logLevel,
 		Contender: &playground.ContenderContext{
-			Enabled: contenderEnabled,
-			Tps:     &contenderTps,
+			Enabled:   contenderEnabled,
+			ExtraArgs: contenderArgs,
 		},
 	}, artifacts)
 	if err := svcManager.Validate(); err != nil {

--- a/playground/components.go
+++ b/playground/components.go
@@ -813,26 +813,110 @@ func (n *nullService) Name() string {
 }
 
 type Contender struct {
-	Tps *uint64 // txs per second, defaults to 20
+	ExtraArgs []string
 }
 
 func (c *Contender) Name() string {
 	return "contender"
 }
 
+// parse "key=value" OR "key value"; remainder after first space is the value (may contain spaces)
+func parseKV(s string) (name, val string, hasVal, usedEq bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", "", false, false
+	}
+	eq := strings.IndexByte(s, '=')
+	ws := indexWS(s)
+
+	// prefer '=' if it appears before any whitespace
+	if eq > 0 && (ws == -1 || eq < ws) {
+		return strings.TrimSpace(s[:eq]), strings.TrimSpace(s[eq+1:]), true, true
+	}
+	if ws == -1 {
+		return s, "", false, false
+	}
+	return strings.TrimSpace(s[:ws]), strings.TrimSpace(s[ws+1:]), true, false
+}
+
+func indexWS(s string) int {
+	for i, r := range s {
+		if r == ' ' || r == '\t' {
+			return i
+		}
+	}
+	return -1
+}
+
 func (c *Contender) Run(service *Service, ctx *ExContext) {
-	tps := uint64(20)
-	if c.Tps != nil {
-		tps = *c.Tps
+	type opt struct {
+		name   string
+		val    string
+		hasVal bool
+	}
+	defaults := []opt{
+		{name: "-l"},
+		{name: "--min-balance", val: "10 ether", hasVal: true},
+		{name: "-r", val: Connect("el", "http"), hasVal: true},
+		{name: "--tps", val: "20", hasVal: true},
 	}
 
-	args := []string{
-		"spam",
-		"-l",                        // loop indefinitely
-		"--min-balance", "10 ether", // give each spammer 10 ether (sender must have 100 ether because default number of spammers is 10)
-		"-r", Connect("el", "http"), // connect to whatever EL node is available
-		"--tps", strconv.FormatUint(uint64(tps), 10), // send tps txs per second as string
+	// Parse extras and track seen flags
+	type extra struct {
+		name   string
+		val    string
+		hasVal bool
+		usedEq bool
 	}
+	var extras []extra
+	seen := map[string]bool{}
+
+	for _, s := range c.ExtraArgs {
+		name, val, hasVal, usedEq := parseKV(s)
+		if name == "" {
+			continue
+		}
+		extras = append(extras, extra{name, val, hasVal, usedEq})
+		seen[name] = true
+	}
+
+	// Minimal conflict example: --loops overrides default "-l"
+	conflict := func(flag string) bool {
+		if seen[flag] {
+			return true
+		}
+		if flag == "-l" && seen["--loops"] {
+			return true
+		}
+		return false
+	}
+
+	args := []string{"spam"}
+
+	// Add defaults unless overridden
+	for _, d := range defaults {
+		if conflict(d.name) {
+			continue
+		}
+		args = append(args, d.name)
+		if d.hasVal {
+			args = append(args, d.val)
+		}
+	}
+
+	// Append extras verbatim, preserving "=" vs space
+	for _, e := range extras {
+		if !e.hasVal {
+			args = append(args, e.name)
+			continue
+		}
+		if e.usedEq {
+			args = append(args, e.name+"="+e.val)
+		} else {
+			args = append(args, e.name, e.val)
+		}
+	}
+
 	service.WithImage("flashbots/contender").
 		WithTag("latest").
 		WithArgs(args...).

--- a/playground/manifest.go
+++ b/playground/manifest.go
@@ -74,8 +74,8 @@ type ContenderContext struct {
 	// Run `contender spam` automatically once all playground services are running.
 	Enabled bool
 
-	// Determines txs/sec for contender spam.
-	Tps *uint64
+	// Provide additional args to contender's CLI
+	ExtraArgs []string
 }
 
 // Execution context

--- a/playground/recipe_buildernet.go
+++ b/playground/recipe_buildernet.go
@@ -61,7 +61,7 @@ func (b *BuilderNetRecipe) Apply(ctx *ExContext, artifacts *Artifacts) *Manifest
 
 	if ctx.Contender.Enabled {
 		svcManager.AddService("contender", &Contender{
-			Tps: ctx.Contender.Tps,
+			ExtraArgs: ctx.Contender.ExtraArgs,
 		})
 	}
 

--- a/playground/recipe_l1.go
+++ b/playground/recipe_l1.go
@@ -109,7 +109,7 @@ func (l *L1Recipe) Apply(ctx *ExContext, artifacts *Artifacts) *Manifest {
 
 	if ctx.Contender.Enabled {
 		svcManager.AddService("contender", &Contender{
-			Tps: ctx.Contender.Tps,
+			ExtraArgs: ctx.Contender.ExtraArgs,
 		})
 	}
 

--- a/playground/recipe_opstack.go
+++ b/playground/recipe_opstack.go
@@ -177,7 +177,7 @@ func (o *OpRecipe) Apply(ctx *ExContext, artifacts *Artifacts) *Manifest {
 
 	if ctx.Contender.Enabled {
 		svcManager.AddService("contender", &Contender{
-			Tps: ctx.Contender.Tps,
+			ExtraArgs: ctx.Contender.ExtraArgs,
 		})
 	}
 


### PR DESCRIPTION
adds a new flag `--contender.arg`, which may be specified multiple times, that passes arbitrary args to contender, complete with default values and the ability to override them, as well as passing additional args.

example:

```sh
go run main.go cook l1 --contender --contender.arg "--tps 100" --contender.arg "-a 20"
```

to see that this is working, run `docker ps`, get the container ID of contender, then run `docker logs $CONTAINER_ID`. You should see 21 accounts getting funded (the default account always gets funded, maybe should fix), and 100 txs being sent. Something like this:

```txt
$ docker logs ffdd2bc90da3
2025-08-13T00:08:40.961364Z  INFO contender: 83: generating seed file at /root/.contender/seed
2025-08-13T00:08:40.986774Z  INFO contender::default_scenarios::fill_block: 57: Attempting to fill blocks with 36000000 gas; sending 100 txs, each with gas limit 360000.
2025-08-13T00:08:40.986788Z  INFO contender::commands::spam: 139: Initializing spammer...
2025-08-13T00:08:41.009647Z  WARN contender::util::utils: 127: No private keys provided. Using default private keys.
2025-08-13T00:08:41.014946Z  INFO contender::util::utils: 292: sending funding txs (21 accounts)...
2025-08-13T00:08:41.015161Z  INFO contender::util::utils: 329: waiting for funding tasks to finish...
```

note: you can also pass positional args, which enables you to run builtin scenarios, and pass them args if needed:

```sh
# run the builtin "storage" scenario, which fills lots of storage slots
go run main.go cook opstack --contender --contender.arg "--tps 40" --contender.arg "storage"

# write to 5000 slots (instead of the default 500)
go run main.go cook opstack --contender --contender.arg "--tps 40" \
--contender.arg "storage" --contender.arg "-s 5000"
```