### PR TITLE
Add Support for Bootnodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ Flags:
 - `--external-builder`: URL of an external builder to use (enables rollup-boost)
 - `--enable-latest-fork` (int): Enables the latest fork (isthmus) at startup (0) or n blocks after genesis.
 
+### Bootnodes
+
+Some recipes have bootnodes in them. Bootnodes using discovery v5 require a static IP so we can use enr to connect. Due to this, we also allow the changing of the network CIDR range that docker uses (for machines where this is already used, etc). This can be done via the `--network-cidr` command:
+
+```bash
+go run main.go cook l1 --interactive --networkCidr 172.19.0.0/16
+```
+
 ### Example Commands
 
 Here's a complete example showing how to run the L1 recipe with the latest fork enabled and custom output directory:

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ var logLevelFlag string
 var bindExternal bool
 var withPrometheus bool
 var networkName string
+var networkCidr string
 var labels playground.MapStringFlag
 var disableLogs bool
 var platform string
@@ -179,6 +180,7 @@ func main() {
 		recipeCmd.Flags().BoolVar(&bindExternal, "bind-external", false, "bind host ports to external interface")
 		recipeCmd.Flags().BoolVar(&withPrometheus, "with-prometheus", false, "whether to gather the Prometheus metrics")
 		recipeCmd.Flags().StringVar(&networkName, "network", "", "network name")
+		recipeCmd.Flags().StringVar(&networkCidr, "networkCidr", "", "network cidr range")
 		recipeCmd.Flags().Var(&labels, "labels", "list of labels to apply to the resources")
 		recipeCmd.Flags().BoolVar(&disableLogs, "disable-logs", false, "disable logs")
 		recipeCmd.Flags().StringVar(&platform, "platform", "", "docker platform to use")
@@ -280,6 +282,7 @@ func runIt(recipe playground.Recipe) error {
 		Interactive:          interactive,
 		BindHostPortsLocally: !bindExternal,
 		NetworkName:          networkName,
+		NetworkCidr:          networkCidr,
 		Labels:               labels,
 		LogInternally:        !disableLogs,
 		Platform:             platform,

--- a/main.go
+++ b/main.go
@@ -227,6 +227,7 @@ func runIt(recipe playground.Recipe) error {
 	builder := recipe.Artifacts()
 	builder.OutputDir(outputFlag)
 	builder.GenesisDelay(genesisDelayFlag)
+	builder.NetworkCidr(networkCidr)
 	artifacts, err := builder.Build()
 	if err != nil {
 		return err

--- a/main.go
+++ b/main.go
@@ -245,6 +245,8 @@ func runIt(recipe playground.Recipe) error {
 
 	// generate the dot graph
 	dotGraph := svcManager.GenerateDotGraph()
+
+	// TODO: Maybe replace with saveDotGraph?
 	if err := artifacts.Out.WriteFile("graph.dot", dotGraph); err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -180,7 +180,7 @@ func main() {
 		recipeCmd.Flags().BoolVar(&bindExternal, "bind-external", false, "bind host ports to external interface")
 		recipeCmd.Flags().BoolVar(&withPrometheus, "with-prometheus", false, "whether to gather the Prometheus metrics")
 		recipeCmd.Flags().StringVar(&networkName, "network", "", "network name")
-		recipeCmd.Flags().StringVar(&networkCidr, "networkCidr", "", "network cidr range")
+		recipeCmd.Flags().StringVar(&networkCidr, "networkCidr", playground.DefaultNetworkCidr, "network cidr range")
 		recipeCmd.Flags().Var(&labels, "labels", "list of labels to apply to the resources")
 		recipeCmd.Flags().BoolVar(&disableLogs, "disable-logs", false, "disable logs")
 		recipeCmd.Flags().StringVar(&platform, "platform", "", "docker platform to use")

--- a/playground/artifacts.go
+++ b/playground/artifacts.go
@@ -65,6 +65,7 @@ type ArtifactsBuilder struct {
 	genesisDelay      uint64
 	applyLatestL2Fork *uint64
 	OpblockTime       uint64
+	Cidr              string
 }
 
 func NewArtifactsBuilder() *ArtifactsBuilder {
@@ -73,6 +74,7 @@ func NewArtifactsBuilder() *ArtifactsBuilder {
 		applyLatestL1Fork: false,
 		genesisDelay:      MinimumGenesisDelay,
 		OpblockTime:       defaultOpBlockTimeSeconds,
+		Cidr:              defaultNetworkCidr,
 	}
 }
 
@@ -101,6 +103,11 @@ func (b *ArtifactsBuilder) OpBlockTime(blockTimeSeconds uint64) *ArtifactsBuilde
 	return b
 }
 
+func (b *ArtifactsBuilder) NetworkCidr(cidr string) *ArtifactsBuilder {
+	b.Cidr = cidr
+	return b
+}
+
 type Artifacts struct {
 	Out *output
 }
@@ -115,7 +122,7 @@ func (b *ArtifactsBuilder) Build() (*Artifacts, error) {
 		b.outputDir = filepath.Join(homeDir, "devnet")
 	}
 
-	out := &output{dst: b.outputDir, homeDir: homeDir}
+	out := &output{dst: b.outputDir, homeDir: homeDir, networkCidr: b.Cidr}
 
 	// check if the output directory exists
 	if out.Exists("") {
@@ -431,6 +438,9 @@ type output struct {
 	lock    sync.Mutex
 
 	enodeAddrSeq *big.Int
+
+	// The network CIDR range
+	networkCidr string
 }
 
 func (o *output) AbsoluteDstPath() (string, error) {

--- a/playground/artifacts.go
+++ b/playground/artifacts.go
@@ -411,6 +411,11 @@ func ConnectEnode(service, id string) string {
 	return ConnectRaw(service, "rpc", "enode", id)
 }
 
+func ConnectENR(service, enr string) string {
+	// We will just hand the entire enr string over as the "user" in this
+	return ConnectRaw(service, "rpc", "enr", enr)
+}
+
 func Connect(service, port string) string {
 	return ConnectRaw(service, port, "http", "")
 }

--- a/playground/catalog.go
+++ b/playground/catalog.go
@@ -27,6 +27,8 @@ func init() {
 	register(&Contender{})
 	register(&BProxy{})
 	register(&WebsocketProxy{})
+	register(&Bootnode{Protocol: BootnodeProtocolDiscV4})
+	register(&Bootnode{Protocol: BootnodeProtocolDiscV5})
 }
 
 func FindComponent(name string) ServiceGen {

--- a/playground/components.go
+++ b/playground/components.go
@@ -1032,6 +1032,11 @@ func (b *Bootnode) Name() string {
 	return fmt.Sprintf("%s-bootnode", protocolNamePrefix)
 }
 
+// GetIP returns the static IP address for the bootnode
+func (b *Bootnode) GetIP() string {
+	return b.IP
+}
+
 func (b *Bootnode) Run(service *Service, ctx *ExContext) {
 	if b.Enode == nil {
 		panic("BUG: Bootnode component must be created with an EnodeAddr.")

--- a/playground/components.go
+++ b/playground/components.go
@@ -1044,7 +1044,10 @@ func (b *Bootnode) Run(service *Service, ctx *ExContext) {
 		WithArgs(
 			"-c",
 			fmt.Sprintf(
-				"socat -v TCP-LISTEN:%d,fork STDOUT & socat -v UDP-LISTEN:%d,fork STDOUT & wait",
+				"trap 'kill -TERM $TCP_PID $UDP_PID 2>/dev/null; exit 0' TERM INT; "+
+					"socat -v TCP-LISTEN:%d,fork STDOUT & TCP_PID=$!; "+
+					"socat -v UDP-LISTEN:%d,fork STDOUT & UDP_PID=$!; "+
+					"wait",
 				b.Port,
 				b.Port,
 			),

--- a/playground/components.go
+++ b/playground/components.go
@@ -1013,7 +1013,6 @@ func (b *Bootnode) GenerateENR() (string, error) {
 }
 
 func (b *Bootnode) Name() string {
-	// return "bootnode"
 	var protocolNamePrefix string
 	switch b.Protocol {
 	case BootnodeProtocolDiscV5:

--- a/playground/local_runner.go
+++ b/playground/local_runner.go
@@ -698,7 +698,7 @@ func (d *LocalRunner) toDockerComposeService(s *Service) (map[string]interface{}
 		"command": args,
 		// Add volume mount for the output directory
 		"volumes": volumesInLine,
-		"labels":   labels,
+		"labels":  labels,
 	}
 
 	if s.IP != "" {

--- a/playground/local_runner.go
+++ b/playground/local_runner.go
@@ -693,15 +693,22 @@ func (d *LocalRunner) toDockerComposeService(s *Service) (map[string]interface{}
 		volumesInLine = append(volumesInLine, fmt.Sprintf("%s:%s", k, v))
 	}
 
-	// add the ports to the labels as well
 	service := map[string]interface{}{
 		"image":   imageName,
 		"command": args,
 		// Add volume mount for the output directory
 		"volumes": volumesInLine,
-		// Add the ethereum network
-		"networks": []string{d.networkName},
 		"labels":   labels,
+	}
+
+	if s.IP != "" {
+		service["networks"] = map[string]interface{}{
+			d.networkName: map[string]interface{}{
+				"ipv4_address": s.IP,
+			},
+		}
+	} else {
+		service["networks"] = []string{d.networkName}
 	}
 
 	if d.platform != "" {

--- a/playground/local_runner.go
+++ b/playground/local_runner.go
@@ -563,6 +563,11 @@ func (d *LocalRunner) applyTemplate(s *Service) ([]string, map[string]string, er
 }
 
 func printAddr(protocol, serviceName string, port int, user string) string {
+	// Special handler for the enr protocol
+	if protocol == "enr" {
+		return user
+	}
+
 	var protocolPrefix string
 	if protocol != "" {
 		protocolPrefix = protocol + "://"
@@ -613,7 +618,10 @@ func (d *LocalRunner) toDockerComposeService(s *Service) (map[string]interface{}
 	}
 
 	// Validate that the image exists
-	imageName := fmt.Sprintf("%s:%s", s.Image, s.Tag)
+	imageName := s.Image
+	if s.Tag != "" {
+		imageName = fmt.Sprintf("%s:%s", s.Image, s.Tag)
+	}
 	if err := d.validateImageExists(imageName); err != nil {
 		return nil, fmt.Errorf("failed to validate image %s: %w", imageName, err)
 	}

--- a/playground/local_runner.go
+++ b/playground/local_runner.go
@@ -29,7 +29,7 @@ import (
 const defaultNetworkName = "ethplayground"
 
 // The default here is docker's default CIDR range. Subsequent networks use .19, .20, etc. If the bridge network is in use, the .17 subnet is used.
-const defaultNetworkCidr = "172.18.0.0/16"
+const DefaultNetworkCidr = "172.19.0.0/16"
 
 // LocalRunner is a component that runs the services from the manifest on the local host machine.
 // By default, it uses docker and docker compose to run all the services.
@@ -229,7 +229,7 @@ func NewLocalRunner(cfg *RunnerConfig) (*LocalRunner, error) {
 
 	var networkGateway string
 	if cfg.NetworkCidr == "" {
-		cfg.NetworkCidr = defaultNetworkCidr
+		cfg.NetworkCidr = DefaultNetworkCidr
 	}
 
 	// Make sure the CDR is actually valid, get the gateway

--- a/playground/manifest.go
+++ b/playground/manifest.go
@@ -90,11 +90,18 @@ type ExContext struct {
 	// access to the output.
 	Output *output
 
-	// Bootnode reference for EL nodes.
-	// TODO: Extend for CL nodes too
-	Bootnode *BootnodeRef
+	// Bootnodes is a map from protocol to manifest entry.
+	Bootnodes map[BootnodeProtocol]*BootnodeRef
 
 	Contender *ContenderContext
+}
+
+func (c *ExContext) GetBootnode(proto BootnodeProtocol) *BootnodeRef {
+	if c.Bootnodes == nil {
+		return nil
+	}
+
+	return c.Bootnodes[proto]
 }
 
 type BootnodeRef struct {
@@ -102,10 +109,18 @@ type BootnodeRef struct {
 	ID      string
 }
 
-func (b *BootnodeRef) Connect() string {
-	return ConnectEnode(b.Service, b.ID)
+func (b *BootnodeRef) Connect(proto BootnodeProtocol) string {
+	switch proto {
+	case BootnodeProtocolDiscV4:
+		return ConnectEnode(b.Service, b.ID)
+	case BootnodeProtocolDiscV5:
+		return ConnectENR(b.Service, b.ID)
+	default:
+		panic(fmt.Sprintf("unexpected playground.BootnodeProtocol: %#v", proto))
+	}
 }
 
+// ServiceGen represents a canonical Component, which is utilized in the creation of components.
 type ServiceGen interface {
 	Run(service *Service, ctx *ExContext)
 	Name() string

--- a/playground/manifest.go
+++ b/playground/manifest.go
@@ -307,6 +307,9 @@ type Service struct {
 	Tag        string `json:"tag,omitempty"`
 	Image      string `json:"image,omitempty"`
 	Entrypoint string `json:"entrypoint,omitempty"`
+
+	// The IP Address of this service. If empty, we let IPAM sort it out.
+	IP string `json:"ip,omitempty"`
 }
 
 type instance struct {

--- a/playground/recipe_l1.go
+++ b/playground/recipe_l1.go
@@ -53,7 +53,24 @@ func (l *L1Recipe) Artifacts() *ArtifactsBuilder {
 }
 
 func (l *L1Recipe) Apply(ctx *ExContext, artifacts *Artifacts) *Manifest {
+	ctx.Bootnodes = make(map[BootnodeProtocol]*BootnodeRef)
 	svcManager := NewManifest(ctx, artifacts.Out)
+
+	elEnode := ctx.Output.GetEnodeAddr()
+	elBootnodeComponent := &Bootnode{Protocol: BootnodeProtocolDiscV4, Enode: elEnode, Port: 30303}
+	svcManager.AddService("el-bootnode", elBootnodeComponent)
+	ctx.Bootnodes[BootnodeProtocolDiscV4] = &BootnodeRef{
+		Service: "el-bootnode",
+		ID:      elEnode.NodeID(),
+	}
+
+	clEnode := ctx.Output.GetEnodeAddr()
+	clBootnodeComponent := &Bootnode{Protocol: BootnodeProtocolDiscV5, Enode: clEnode, Port: 9000}
+	svcManager.AddService("cl-bootnode", clBootnodeComponent)
+	ctx.Bootnodes[BootnodeProtocolDiscV5] = &BootnodeRef{
+		Service: "cl-bootnode",
+		ID:      clEnode.NodeID(),
+	}
 
 	svcManager.AddService("el", &RethEL{
 		UseRethForValidation: l.useRethForValidation,

--- a/playground/recipe_l1.go
+++ b/playground/recipe_l1.go
@@ -60,7 +60,7 @@ func (l *L1Recipe) Apply(ctx *ExContext, artifacts *Artifacts) *Manifest {
 	// TODO: Make this more configurable.
 	elBootnodeIP, err := GetIPFromCIDR(artifacts.Out.networkCidr, 10)
 	if err != nil {
-		panic("BUG: We got an invalid CIDR that somehow slipped through")
+		panic(fmt.Sprintf("BUG: We got an invalid CIDR that somehow slipped through for el; error = %v", err))
 	}
 
 	elEnode := ctx.Output.GetEnodeAddr()
@@ -73,7 +73,7 @@ func (l *L1Recipe) Apply(ctx *ExContext, artifacts *Artifacts) *Manifest {
 
 	clBootnodeIP, err := GetIPFromCIDR(artifacts.Out.networkCidr, 11)
 	if err != nil {
-		panic("BUG: We got an invalid CIDR that somehow slipped through")
+		panic(fmt.Sprintf("BUG: We got an invalid CIDR that somehow slipped through for cl; error = %v", err))
 	}
 
 	clEnode := ctx.Output.GetEnodeAddr()

--- a/playground/recipe_opstack.go
+++ b/playground/recipe_opstack.go
@@ -92,7 +92,7 @@ func (o *OpRecipe) Apply(ctx *ExContext, artifacts *Artifacts) *Manifest {
 	svcManager.AddService("el-bootnode", elBootnode)
 
 	ctx.Bootnodes[BootnodeProtocolDiscV4] = &BootnodeRef{
-		Service: "op-geth-el-bootnode",
+		Service: "el-bootnode",
 		ID:      elBootnode.Enode.NodeID(),
 	}
 

--- a/playground/recipe_opstack.go
+++ b/playground/recipe_opstack.go
@@ -1,6 +1,8 @@
 package playground
 
 import (
+	"fmt"
+
 	flag "github.com/spf13/pflag"
 )
 
@@ -88,7 +90,12 @@ func (o *OpRecipe) Apply(ctx *ExContext, artifacts *Artifacts) *Manifest {
 
 	elEnode := ctx.Output.GetEnodeAddr()
 
-	elBootnode := &Bootnode{Protocol: BootnodeProtocolDiscV4, Enode: elEnode, Port: 30303}
+	elBootnodeIP, err := GetIPFromCIDR(artifacts.Out.networkCidr, 10)
+	if err != nil {
+		panic(fmt.Sprintf("BUG: We got an invalid CIDR that somehow slipped through for el; error = %v", err))
+	}
+
+	elBootnode := &Bootnode{Protocol: BootnodeProtocolDiscV4, Enode: elEnode, Port: 30303, IP: elBootnodeIP}
 	svcManager.AddService("el-bootnode", elBootnode)
 
 	ctx.Bootnodes[BootnodeProtocolDiscV4] = &BootnodeRef{

--- a/playground/utils.go
+++ b/playground/utils.go
@@ -2,6 +2,7 @@ package playground
 
 import (
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 )
@@ -67,4 +68,24 @@ func (n *MapStringFlag) Set(s string) error {
 	}
 	(*n)[k] = v
 	return nil
+}
+
+func GetGatewayFromCIDR(cidr string) (string, error) {
+	ip, _, err := net.ParseCIDR(cidr)
+
+	if err != nil {
+		return "", err
+	}
+
+	// The ip address is whatever the base was. We make the assumption it'll
+	// be a .0/whatever in this case, (i.e. the gateway will always be .1).
+	gateway := ip.To4()
+	if gateway == nil {
+		return "", fmt.Errorf("failed to get an ipv4 base address from the cidr")
+	}
+
+	// Set the last octet to the default gateway (.1)
+	gateway[3] = 1
+
+	return gateway.String(), nil
 }

--- a/playground/utils.go
+++ b/playground/utils.go
@@ -70,22 +70,25 @@ func (n *MapStringFlag) Set(s string) error {
 	return nil
 }
 
+// GetGatewayFromCIDR returns the gateway from the ip address is whatever the base was. We make the assumption it'll be a .0/whatever in this case, (i.e. the gateway will always be .1).
 func GetGatewayFromCIDR(cidr string) (string, error) {
+	return GetIPFromCIDR(cidr, 1)
+}
+
+// GetIPFromCIDR returns an IP from the CIDR range with the last octet filled out with any numeric value in the range 0-cidr max.
+func GetIPFromCIDR(cidr string, lastOctet int) (string, error) {
 	ip, _, err := net.ParseCIDR(cidr)
 
 	if err != nil {
 		return "", err
 	}
-
-	// The ip address is whatever the base was. We make the assumption it'll
-	// be a .0/whatever in this case, (i.e. the gateway will always be .1).
 	gateway := ip.To4()
 	if gateway == nil {
 		return "", fmt.Errorf("failed to get an ipv4 base address from the cidr")
 	}
 
-	// Set the last octet to the default gateway (.1)
-	gateway[3] = 1
+	// Set the last octet to the user-provided value
+	gateway[3] = byte(lastOctet)
 
 	return gateway.String(), nil
 }

--- a/playground/utils_test.go
+++ b/playground/utils_test.go
@@ -1,0 +1,48 @@
+package playground_test
+
+import (
+	"testing"
+
+	"github.com/flashbots/builder-playground/playground"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetGatewayFromCIDR(t *testing.T) {
+	testCases := []struct {
+		name          string
+		cidr          string
+		expected      string
+		expectError   bool
+	}{
+		{
+			name:          "valid cidr /16",
+			cidr:          "172.18.0.0/16",
+			expected:      "172.18.0.1",
+			expectError:   false,
+		},
+		{
+			name:          "valid cidr /24",
+			cidr:          "192.168.1.0/24",
+			expected:      "192.168.1.1",
+			expectError:   false,
+		},
+		{
+			name:          "invalid cidr",
+			cidr:          "invalid",
+			expected:      "",
+			expectError:   true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gateway, err := playground.GetGatewayFromCIDR(tc.cidr)
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expected, gateway)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Why?
This feature implements the generic bootndoe component to allow nodes that support it to reference a bootnode in their startup configuration. This is advantageous to have as it allows for a given node to use the existing connection abstraction system when the eventual capabilities are added to support multiple nodes communicating within a given chain.

# What Changes Did I Make?
I specifically tried to be surgical here to avoid a massive PR. In short, I added the following:
- Implemented static IP assignment and CIDR range allocation to enable ENR addresses to be constructed (not possible using the existing abstraction as the docker compose hostname approach is not possible).
- Implemented the bootnode component to use the socat container to print inbound connects (for verification purposes).
- Added the ability to statically assign IPs with an additional interface called `ServiceWithIP` that allows a service that needs a static IP to have it propagate down to the docker compose.