### PR TITLE
Remove ready interface

### DIFF
--- a/main.go
+++ b/main.go
@@ -327,11 +327,6 @@ func runIt(recipe playground.Recipe) error {
 		return fmt.Errorf("failed to wait for service readiness: %w", err)
 	}
 
-	if err := playground.CompleteReady(dockerRunner.Instances()); err != nil {
-		dockerRunner.Stop()
-		return fmt.Errorf("failed to complete ready: %w", err)
-	}
-
 	// get the output from the recipe
 	output := recipe.Output(svcManager)
 	if len(output) > 0 {

--- a/playground/manifest.go
+++ b/playground/manifest.go
@@ -111,10 +111,6 @@ type ServiceGen interface {
 	Name() string
 }
 
-type ServiceReady interface {
-	Ready(instance *instance) error
-}
-
 // ReleaseService is a service that can also be runned as an artifact in the host machine
 type ReleaseService interface {
 	ReleaseArtifact() *release

--- a/playground/watchdog.go
+++ b/playground/watchdog.go
@@ -34,14 +34,3 @@ func RunWatchdog(out *output, instances []*instance) error {
 	}
 	return nil
 }
-
-func CompleteReady(instances []*instance) error {
-	for _, s := range instances {
-		if readyFn, ok := s.component.(ServiceReady); ok {
-			if err := readyFn.Ready(s); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}


### PR DESCRIPTION
This PR removes the Ready interface. I believe this was not used in a while since the ready checks have been replaced with the watchdog checks and the docker-compose ready checks. Note that this can be introduced later in the future on top of the watchdog service (i.e. the service is ready if at least one watchdog check has passed).

I think it might make sense to introduce something like this in the future but with a different shape.