### PR TITLE
Make el client listens on all interfaces for P2P (instead of `127.0.0.1`)

### DIFF
--- a/playground/components.go
+++ b/playground/components.go
@@ -719,6 +719,7 @@ func (o *OpReth) Run(service *Service, ctx *ExContext) {
 			"--disable-discovery",
 			"--color", "never",
 			"--metrics", `0.0.0.0:{{Port "metrics" 9090}}`,
+			"--addr", "0.0.0.0",
 			"--port", `{{Port "rpc" 30303}}`).
 		WithArtifact("/data/jwtsecret", "jwtsecret").
 		WithArtifact("/data/l2-genesis.json", "l2-genesis.json").


### PR DESCRIPTION
This make it possible to sync another execution client from outside the Docker compose.