### PR TITLE
Adding possibility to add more prefunded accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ docker logs -f $(docker ps | grep contender | cut -d' ' -f1)
 - `--log-level` (string): Log level to use (debug, info, warn, error, fatal). Defaults to `info`.
 - `--labels` (key=val): Custom labels to apply to your deployment.
 - `--disable-logs` (bool): Disable the logs for the services. Defaults to `false`.
+- `--prefunded-accounts` (string, repeated): Fund this account in addition to static prefunded accounts, the input should the account's private key in hexadecimal format prefixed with 0x, the account is added to L1 and to L2 (if present).
 - `--contender` (bool): Enable [contender](https://github.com/flashbots/contender) spammer. Required to use other contender flags.
   - `--contender.arg` (string): Pass custom args to the contender CLI.
   Example: `--contender.arg "--tpb 20"`
@@ -125,6 +126,21 @@ docker logs -f $(docker ps | grep contender | cut -d' ' -f1)
 - `--with-prometheus` (bool); Whether to deploy a Prometheus server and gather metrics. Defaults to `false`.
 
 To stop the playground, press `Ctrl+C`.
+
+### Static Prefunded Accounts
+
+The following addresses are pre-funded on L1 and to L2 (if present), all with a balance of `0x10000000000000000000000 wei` (equivalent to `309485009.8213451 ETH`):
+
+- `0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266` (Private key `0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80`)
+- `0x70997970c51812dc3a010c7d01b50e0d17dc79c8` (Private key `0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d`)
+- `0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc` (Private key `0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a`)
+- `0x90f79bf6eb2c4f870365e785982e1f101e93b906` (Private key `0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6`)
+- `0x15d34aaf54267db7d7c367839aaf71a00a2c6a65` (Private key `0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a`)
+- `0x9965507d1a55bcc2695c58ba16fb37d819b0a4dc` (Private key `0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba`)
+- `0x976ea74026e726554db657fa54763abd0c3a0aa9` (Private key `0x92db14e403b83dfe3df233f83dfa3a0d7096f21ca9b0d6d6b8d88b2b4ec1564e`)
+- `0x14dc79964da2c08b23698b3d3cc7ca32193d9955` (Private key `0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356`)
+- `0x23618e81e3f5cdf7f54c3d65f7fbc0abf5b21e8f` (Private key `0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97`)
+- `0xa0ee7a142d267c1f36714e4a8f75612f20a79720` (Private key `0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6`)
 
 ## Logs
 

--- a/main.go
+++ b/main.go
@@ -18,24 +18,25 @@ import (
 var version = "dev"
 
 var (
-	outputFlag       string
-	genesisDelayFlag uint64
-	withOverrides    []string
-	watchdog         bool
-	dryRun           bool
-	interactive      bool
-	timeout          time.Duration
-	logLevelFlag     string
-	bindExternal     bool
-	withPrometheus   bool
-	networkName      string
-	labels           playground.MapStringFlag
-	disableLogs      bool
-	platform         string
-	contenderEnabled bool
-	contenderArgs    []string
-	contenderTarget  string
-	detached         bool
+	outputFlag        string
+	genesisDelayFlag  uint64
+	withOverrides     []string
+	watchdog          bool
+	dryRun            bool
+	interactive       bool
+	timeout           time.Duration
+	logLevelFlag      string
+	bindExternal      bool
+	withPrometheus    bool
+	networkName       string
+	labels            playground.MapStringFlag
+	disableLogs       bool
+	platform          string
+	contenderEnabled  bool
+	contenderArgs     []string
+	contenderTarget   string
+	detached          bool
+	prefundedAccounts []string
 )
 
 var rootCmd = &cobra.Command{
@@ -181,6 +182,7 @@ func main() {
 		recipeCmd.Flags().StringArrayVar(&contenderArgs, "contender.arg", []string{}, "add/override contender CLI flags")
 		recipeCmd.Flags().StringVar(&contenderTarget, "contender.target", "", "override the node that contender spams -- accepts names like \"el\"")
 		recipeCmd.Flags().BoolVar(&detached, "detached", false, "Detached mode: Run the recipes in the background")
+		recipeCmd.Flags().StringArrayVar(&prefundedAccounts, "prefunded-accounts", []string{}, "Fund this account in addition to static prefunded accounts, the input should the account's private key in hexadecimal format prefixed with 0x, the account is added to L1 and to L2 (if present)")
 
 		startCmd.AddCommand(recipeCmd)
 	}
@@ -226,6 +228,7 @@ func runIt(recipe playground.Recipe) error {
 	builder := recipe.Artifacts()
 	builder.OutputDir(outputFlag)
 	builder.GenesisDelay(genesisDelayFlag)
+	builder.PrefundedAccounts(prefundedAccounts)
 	artifacts, err := builder.Build()
 	if err != nil {
 		return err

--- a/playground/artifacts.go
+++ b/playground/artifacts.go
@@ -69,6 +69,7 @@ type ArtifactsBuilder struct {
 	applyLatestL2Fork    *uint64
 	l1BlockTimeInSeconds uint64
 	opBlockTimeInSeconds uint64
+	prefundedAccounts    []string
 }
 
 func NewArtifactsBuilder() *ArtifactsBuilder {
@@ -109,6 +110,32 @@ func (b *ArtifactsBuilder) L1BlockTime(blockTimeSeconds uint64) *ArtifactsBuilde
 func (b *ArtifactsBuilder) OpBlockTime(blockTimeSeconds uint64) *ArtifactsBuilder {
 	b.opBlockTimeInSeconds = blockTimeSeconds
 	return b
+}
+
+func (b *ArtifactsBuilder) PrefundedAccounts(accounts []string) *ArtifactsBuilder {
+	b.prefundedAccounts = accounts
+	return b
+}
+
+var staticPrefundedAccounts = []string{
+	"0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+	"0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d",
+	"0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a",
+	"0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6",
+	"0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a",
+	"0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba",
+	"0x92db14e403b83dfe3df233f83dfa3a0d7096f21ca9b0d6d6b8d88b2b4ec1564e",
+	"0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356",
+	"0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97",
+	"0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6",
+}
+
+func (b *ArtifactsBuilder) getPrefundedAccounts() []string {
+	if len(b.prefundedAccounts) > 0 {
+		return append(append([]string{}, staticPrefundedAccounts...), b.prefundedAccounts...)
+	}
+
+	return staticPrefundedAccounts
 }
 
 type Artifacts struct {
@@ -171,7 +198,7 @@ func (b *ArtifactsBuilder) Build() (*Artifacts, error) {
 	// add pre-funded accounts
 	prefundedBalance, _ := new(big.Int).SetString("10000000000000000000000", 16)
 
-	for _, privStr := range prefundedAccounts {
+	for _, privStr := range b.getPrefundedAccounts() {
 		priv, err := getPrivKey(privStr)
 		if err != nil {
 			return nil, err
@@ -294,7 +321,7 @@ func (b *ArtifactsBuilder) Build() (*Artifacts, error) {
 		// Update the allocs to include the same prefunded accounts as the L1 genesis.
 		allocs := make(map[string]interface{})
 		input["alloc"] = allocs
-		for _, privStr := range prefundedAccounts {
+		for _, privStr := range b.getPrefundedAccounts() {
 			priv, err := getPrivKey(privStr)
 			if err != nil {
 				return nil, err
@@ -687,19 +714,6 @@ func isByteArray(t reflect.Type) bool {
 
 func isByteSlice(t reflect.Type) bool {
 	return t.Kind() == reflect.Slice && t.Elem().Kind() == reflect.Uint8
-}
-
-var prefundedAccounts = []string{
-	"0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
-	"0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d",
-	"0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a",
-	"0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6",
-	"0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a",
-	"0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba",
-	"0x92db14e403b83dfe3df233f83dfa3a0d7096f21ca9b0d6d6b8d88b2b4ec1564e",
-	"0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356",
-	"0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97",
-	"0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6",
 }
 
 func applyTemplate2(templateStr []byte, input interface{}) ([]byte, error) {


### PR DESCRIPTION
Add possibility to add more prefunded accounts to the L1 generated genesis by accepting a repeated `[]string` flag `--prefunded-account` which accepts the same format (private key in hex) as the static prefunded accounts.

I debated about putting the `prefunded-account` flag on the L1 recipe directly, to scope it just to this. Maybe it would be preferable, let me know what do you think.