### PR TITLE
fix(ci/cd): use `macos-latest` for osx artifacts

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -54,7 +54,7 @@ jobs:
     name: Artifacts
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-13]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out code


### PR DESCRIPTION
To fix gh actions