### PR TITLE
Use context cancel in complete ready

### DIFF
--- a/main.go
+++ b/main.go
@@ -254,7 +254,7 @@ func runIt(recipe playground.Recipe) error {
 		cancel()
 	}()
 
-	if err := dockerRunner.Run(); err != nil {
+	if err := dockerRunner.Run(ctx); err != nil {
 		dockerRunner.Stop()
 		return fmt.Errorf("failed to run docker: %w", err)
 	}
@@ -287,7 +287,7 @@ func runIt(recipe playground.Recipe) error {
 
 	fmt.Printf("\nWaiting for network to be ready for transactions...\n")
 	networkReadyStart := time.Now()
-	if err := playground.CompleteReady(dockerRunner.Instances()); err != nil {
+	if err := playground.CompleteReady(ctx, dockerRunner.Instances()); err != nil {
 		dockerRunner.Stop()
 		return fmt.Errorf("network not ready: %w", err)
 	}

--- a/playground/components.go
+++ b/playground/components.go
@@ -359,9 +359,9 @@ func (o *OpGeth) Apply(manifest *Manifest) {
 		WithArtifact("/data/p2p_key.txt", o.Enode.Artifact)
 }
 
-func opGethReadyFn(instance *instance) error {
+func opGethReadyFn(ctx context.Context, instance *instance) error {
 	opGethURL := fmt.Sprintf("http://localhost:%d", instance.service.MustGetPort("http").HostPort)
-	return waitForFirstBlock(context.Background(), opGethURL, 60*time.Second)
+	return waitForFirstBlock(ctx, opGethURL, 60*time.Second)
 }
 
 func opGethWatchdogFn(out io.Writer, instance *instance, ctx context.Context) error {
@@ -446,9 +446,9 @@ func (r *RethEL) Apply(manifest *Manifest) {
 			rethURL := fmt.Sprintf("http://localhost:%d", instance.service.MustGetPort("http").HostPort)
 			return watchChainHead(out, rethURL, 12*time.Second)
 		}).
-		WithReadyFn(func(instance *instance) error {
+		WithReadyFn(func(ctx context.Context, instance *instance) error {
 			elURL := fmt.Sprintf("http://localhost:%d", instance.service.MustGetPort("http").HostPort)
-			return waitForFirstBlock(context.Background(), elURL, 60*time.Second)
+			return waitForFirstBlock(ctx, elURL, 60*time.Second)
 		}).
 		WithArtifact("/data/genesis.json", "genesis.json").
 		WithArtifact("/data/jwtsecret", "jwtsecret").

--- a/playground/local_runner.go
+++ b/playground/local_runner.go
@@ -976,7 +976,7 @@ func CreatePrometheusServices(manifest *Manifest, out *output) error {
 	return nil
 }
 
-func (d *LocalRunner) Run() error {
+func (d *LocalRunner) Run(ctx context.Context) error {
 	go d.trackContainerStatusAndLogs()
 
 	yamlData, err := d.generateDockerCompose()
@@ -996,7 +996,7 @@ func (d *LocalRunner) Run() error {
 	}
 
 	// First start the services that are running in docker-compose
-	cmd := exec.Command("docker", "compose", "-f", d.out.dst+"/docker-compose.yaml", "up", "-d")
+	cmd := exec.CommandContext(ctx, "docker", "compose", "-f", d.out.dst+"/docker-compose.yaml", "up", "-d")
 
 	var errOut bytes.Buffer
 	cmd.Stderr = &errOut

--- a/playground/manifest.go
+++ b/playground/manifest.go
@@ -290,7 +290,7 @@ type Service struct {
 }
 
 type watchdogFn func(out io.Writer, instance *instance, ctx context.Context) error
-type readyFn func(instance *instance) error
+type readyFn func(ctx context.Context, instance *instance) error
 
 type instance struct {
 	service *Service

--- a/playground/watchdog.go
+++ b/playground/watchdog.go
@@ -30,10 +30,10 @@ func RunWatchdog(out *output, instances []*instance) error {
 	return nil
 }
 
-func CompleteReady(instances []*instance) error {
+func CompleteReady(ctx context.Context, instances []*instance) error {
 	for _, s := range instances {
 		if readyFn := s.service.readyFn; readyFn != nil {
-			if err := readyFn(s); err != nil {
+			if err := readyFn(ctx, s); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Closes #235 

The `exec.Command` would already close after the Ctrl-C signal was received, I changed it to use the main context reference anyway just in case.

The only other side that was blocking was the `CompleteReady` function which did not have the context reference. I changed that.