### PR TITLE
CI: use faster warpbuild runners

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   test:
     name: E2E test (${{ matrix.flags }})
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-8x
     strategy:
       matrix:
         flags:

--- a/.github/workflows/docker-utils-release.yaml
+++ b/.github/workflows/docker-utils-release.yaml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   docker:
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-8x
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-8x
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Available runners on WarpBuild: https://docs.warpbuild.com/ci/cloud-runners