### PR TITLE
Update readme with telemetry info

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,66 +73,9 @@ $ builder-playground cook l1 --latest-fork --output ~/my-builder-testnet --genes
   - `--contender.arg` (string): Pass custom args to the contender CLI. 
   Example: `--contender.arg "--tpb 20"`
   - `--contender.target` (string): Change the default target node to spam. On the `l1` recipe, the default is "el", and on `opstack` it's "op-geth".
+- `--with-prometheus` (bool); Whether to deploy a Prometheus server and gather metrics. Defaults to `false`.
 
 To stop the playground, press `Ctrl+C`.
-
-## Network Readiness
-
-The playground can expose a `/readyz` HTTP endpoint to check if the network is ready to accept transactions (i.e., blocks are being produced).
-
-### Readyz Endpoint
-
-Enable the readyz server with the `--readyz-port` flag:
-
-```bash
-$ builder-playground cook l1 --readyz-port 8080
-```
-
-Then check readiness:
-
-```bash
-$ curl http://localhost:8080/readyz
-{"ready":true}
-```
-
-Returns:
-- `200 OK` with `{"ready": true}` when the network is producing blocks
-- `503 Service Unavailable` with `{"ready": false, "error": "..."}` otherwise
-
-### Wait-Ready Command
-
-Use the `wait-ready` command to block until the network is ready:
-
-```bash
-$ builder-playground wait-ready [flags]
-```
-
-Flags:
-- `--url` (string): readyz endpoint URL. Defaults to `http://localhost:8080/readyz`
-- `--timeout` (duration): Maximum time to wait. Defaults to `60s`
-- `--interval` (duration): Poll interval. Defaults to `1s`
-
-Example:
-
-```bash
-# In terminal 1: Start the playground with readyz enabled
-$ builder-playground cook l1 --readyz-port 8080
-
-# In terminal 2: Wait for the network to be ready
-$ builder-playground wait-ready --timeout 120s
-Waiting for http://localhost:8080/readyz (timeout: 2m0s, interval: 1s)
-  [1s] Attempt 1: 503 Service Unavailable
-  [2s] Attempt 2: 503 Service Unavailable
-  [3s] Ready! (200 OK)
-```
-
-This is useful for CI/CD pipelines or scripts that need to wait for the network before deploying contracts.
-
-Alternatively, use a bash one-liner:
-
-```bash
-$ timeout 60 bash -c 'until curl -sf http://localhost:8080/readyz | grep -q "\"ready\":true"; do sleep 1; done'
-```
 
 ## Inspect
 
@@ -157,6 +100,26 @@ Removes a recipe running in the background
 
 ```bash
 $ builder-playground clean [--output ./output]
+```
+
+## Telemetry
+
+The Builder Playground includes built-in Prometheus metrics collection. When you run any recipe with the `--with-prometheus` flag, the system automatically deploys a Prometheus server and gathers metrics from all services in your deployment.
+
+Prometheus automatically discovers services by looking for a port with the metrics label. You can define a metrics port in your component like this:
+
+```go
+WithArgs("--metrics", `0.0.0.0:{{Port "metrics" 9090}}`)
+```
+
+By default, Prometheus scrapes the `/metrics` path, but services can override this by specifying a custom path with `WithLabel("metrics_path", "/custom/path")`. All configured services are automatically registered as scrape targets.
+
+### Usage
+Enable Prometheus for any recipe:
+
+```bash
+$ builder-playground cook l1 --with-prometheus
+$ builder-playground cook opstack --with-prometheus
 ```
 
 ## Internals


### PR DESCRIPTION
This PR does two things:
- Removes the stale docs on the ready endpoint which was removed in #214.
- Adds docs on the telemetry/Prometheus functionality.