### PR TITLE
Use config directly on runtime

### DIFF
--- a/playground/local_runner.go
+++ b/playground/local_runner.go
@@ -206,6 +206,7 @@ func NewLocalRunner(cfg *RunnerConfig) (*LocalRunner, error) {
 	}
 
 	d := &LocalRunner{
+		config:        cfg,
 		out:           cfg.Out,
 		manifest:      cfg.Manifest,
 		client:        client,


### PR DESCRIPTION
I just realized we are copying back and forth the values from the runtime config into the runtime, we can get rid of that by using the config struct itself. Note that there might be some values that we can still reuse from config (i.e. overrides). I did not touch those because they have a bit more of a hidden logic and I will do a followup PR to clean them.