### PR TITLE
Do not return docker-compose output on ctx cancelled

### DIFF
--- a/main.go
+++ b/main.go
@@ -117,6 +117,8 @@ func main() {
 			Use:   recipe.Name(),
 			Short: recipe.Description(),
 			RunE: func(cmd *cobra.Command, args []string) error {
+				// Silence usage for internal errors, not flag parsing errors
+				cmd.SilenceUsage = true
 				return runIt(recipe)
 			},
 		}

--- a/playground/local_runner.go
+++ b/playground/local_runner.go
@@ -1095,6 +1095,10 @@ func (d *LocalRunner) Run(ctx context.Context) error {
 	cmd.Stderr = &errOut
 
 	if err := cmd.Run(); err != nil {
+		// Don't return error if context was cancelled
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		return fmt.Errorf("failed to run docker-compose: %w, err: %s", err, errOut.String())
 	}
 


### PR DESCRIPTION
If we context cancel while docker-compose is running, it outputs the long interactive docker-compose output (this is, state of the containers, an update when they are down, etc...). This PR removes that output if the reason to cancel the execution was the context closed.