### PR TITLE
Use human friendly random pet names for session ID

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,10 +8,10 @@ require (
 	github.com/charmbracelet/bubbles v0.20.0
 	github.com/charmbracelet/lipgloss v1.0.0
 	github.com/docker/docker v28.0.1+incompatible
+	github.com/dustinkirkland/golang-petname v0.0.0-20240428194347-eebcea082ee0
 	github.com/ethereum/go-ethereum v1.15.10
 	github.com/flashbots/go-boost-utils v1.9.1-0.20250819134059-e5294cb450c9
 	github.com/flashbots/mev-boost-relay v0.32.0-rc2
-	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/holiman/uint256 v1.3.2
 	github.com/sirupsen/logrus v1.9.3
@@ -75,6 +75,7 @@ require (
 	github.com/golang/snappy v0.0.5-0.20231225225746-43d5d4cd4e0e // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -110,6 +110,8 @@ github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj
 github.com/docker/go-connections v0.5.0/go.mod h1:ov60Kzw0kKElRwhNs9UlUHAE/F9Fe6GLaXnqyDdmEXc=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/dustinkirkland/golang-petname v0.0.0-20240428194347-eebcea082ee0 h1:aYo8nnk3ojoQkP5iErif5Xxv0Mo0Ga/FR5+ffl/7+Nk=
+github.com/dustinkirkland/golang-petname v0.0.0-20240428194347-eebcea082ee0/go.mod h1:8AuBTZBRSFqEYBPYULd+NN474/zZBLP+6WeT5S9xlAc=
 github.com/emicklei/dot v1.8.0 h1:HnD60yAKFAevNeT+TPYr9pb8VB9bqdeSo0nzwIW6IOI=
 github.com/emicklei/dot v1.8.0/go.mod h1:DeV7GvQtIw4h2u73RKBkkFdvVAz0D9fzeJrgPW6gy/s=
 github.com/emicklei/go-restful/v3 v3.11.0 h1:rAQeMHw1c7zTmncogyy8VvRZwtkmkZ4FxERmMY4rD+g=

--- a/main.go
+++ b/main.go
@@ -298,6 +298,7 @@ func runIt(recipe playground.Recipe) error {
 		return fmt.Errorf("network not ready: %w", err)
 	}
 	fmt.Printf("Network is ready for transactions (took %.1fs)\n", time.Since(networkReadyStart).Seconds())
+	fmt.Println("Session ID:", svcManager.ID)
 
 	// get the output from the recipe
 	output := recipe.Output(svcManager)

--- a/playground/manifest.go
+++ b/playground/manifest.go
@@ -11,7 +11,7 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/flashbots/builder-playground/utils"
 	flag "github.com/spf13/pflag"
 )
 
@@ -74,7 +74,7 @@ func (m *Manifest) ApplyOverrides(overrides map[string]string) error {
 func NewManifest(ctx *ExContext, out *output) *Manifest {
 	ctx.Output = out
 	return &Manifest{
-		ID:        uuid.New().String(),
+		ID:        utils.GeneratePetName(),
 		ctx:       ctx,
 		out:       out,
 		overrides: make(map[string]string),

--- a/utils/pet_name.go
+++ b/utils/pet_name.go
@@ -1,0 +1,12 @@
+package utils
+
+import (
+	petname "github.com/dustinkirkland/golang-petname"
+)
+
+// GeneratePetName generates a random pet name like perfect-bee.
+// These names are useful as human friendly identifiers.
+func GeneratePetName() string {
+	petname.NonDeterministicMode()
+	return petname.Generate(2, "-")
+}


### PR DESCRIPTION
Makes it easier to refer to sessions when interacting or debugging (e.g. `civil-toad`, `perfect-bee`)