### PR TITLE
Cleanup docker components after tests

### DIFF
--- a/playground/components_test.go
+++ b/playground/components_test.go
@@ -186,7 +186,10 @@ func (tt *testFramework) test(s ServiceGen, args []string) *Manifest {
 	dockerRunner, err := NewLocalRunner(cfg)
 	require.NoError(t, err)
 
-	dockerRunner.cleanupNetwork = true
+	t.Cleanup(func() {
+		require.NoError(t, dockerRunner.Stop(false))
+	})
+
 	tt.runner = dockerRunner
 
 	err = dockerRunner.Run(context.Background())

--- a/playground/local_runner.go
+++ b/playground/local_runner.go
@@ -59,9 +59,6 @@ type LocalRunner struct {
 	// tasks tracks the status of each service
 	tasksMtx sync.Mutex
 	tasks    map[string]*task
-
-	// whether to remove the network name after execution (used in testing)
-	cleanupNetwork bool
 }
 
 type task struct {


### PR DESCRIPTION
The docker containers were not being cleaned up after tests executions.