### PR TITLE
Add ungraceful shutdown and use for curl containers

### DIFF
--- a/playground/local_runner.go
+++ b/playground/local_runner.go
@@ -568,6 +568,10 @@ func (d *LocalRunner) toDockerComposeService(s *Service) (map[string]interface{}
 		}
 	}
 
+	if s.UngracefulShutdown {
+		service["stop_grace_period"] = "0s"
+	}
+
 	if s.DependsOn != nil {
 		depends := map[string]interface{}{}
 

--- a/playground/manifest.go
+++ b/playground/manifest.go
@@ -201,7 +201,8 @@ func (s *Manifest) Validate() error {
 				WithImage("alpine/curl").
 				WithTag("latest").
 				WithArgs("sleep", "infinity").
-				WithReady(readyCheck)
+				WithReady(readyCheck).
+				WithUngracefulShutdown()
 		}
 
 		// validate node port references
@@ -329,6 +330,8 @@ type Service struct {
 	Image      string `json:"image,omitempty"`
 	Entrypoint string `json:"entrypoint,omitempty"`
 	HostPath   string `json:"host_path,omitempty"`
+
+	UngracefulShutdown bool `json:"ungraceful_shutdown,omitempty"`
 
 	release *release
 }
@@ -489,6 +492,11 @@ type ReadyCheck struct {
 	StartPeriod time.Duration `json:"start_period"`
 	Timeout     time.Duration `json:"timeout"`
 	Retries     int           `json:"retries"`
+}
+
+func (s *Service) WithUngracefulShutdown() *Service {
+	s.UngracefulShutdown = true
+	return s
 }
 
 func (s *Service) DependsOnHealthy(name string) *Service {


### PR DESCRIPTION
This removes the several seconds exit hang introduced with the curl containers we added recently.