### PR TITLE
Add flag to enable L2 artifacts

### DIFF
--- a/playground/artifacts_test.go
+++ b/playground/artifacts_test.go
@@ -25,6 +25,7 @@ func TestL2PrefundedAccounts(t *testing.T) {
 	o := newTestOutput(t)
 
 	b := NewArtifactsBuilder()
+	b.WithL2()
 	require.NoError(t, b.Build(o))
 
 	genesisRaw, err := o.Read("l2-genesis.json")

--- a/playground/recipe_opstack.go
+++ b/playground/recipe_opstack.go
@@ -67,6 +67,7 @@ func (o *OpRecipe) Flags() *flag.FlagSet {
 
 func (o *OpRecipe) Artifacts() *ArtifactsBuilder {
 	builder := NewArtifactsBuilder()
+	builder.WithL2()
 	builder.ApplyLatestL2Fork(o.enableLatestFork)
 	builder.OpBlockTime(o.blockTime)
 	return builder


### PR DESCRIPTION
By default, L2 artifacts are always generated. This PR adds a new function `WithL2` on the artifacts builder to enable the construction of those artifacts.