### PR TITLE
Fix panic in `debug probe`

### DIFF
--- a/main.go
+++ b/main.go
@@ -132,12 +132,17 @@ var inspectCmd = &cobra.Command{
 }
 
 var debugCmd = &cobra.Command{
-	Use: "debug",
+	Use:   "debug",
+	Short: "Debug commands for running services",
 }
 
 var probeCmd = &cobra.Command{
-	Use: "probe",
+	Use:   "probe <service>",
+	Short: "Execute a service's health check manually",
+	Long:  "Manually runs the configured Docker health check command for a service and displays the result.",
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
 		serviceName := args[0]
 
 		resp, err := playground.ExecuteHealthCheckManually(serviceName)


### PR DESCRIPTION
before:

`./builder-playground debug probe`

```
goroutine 1 [running]:
main.init.func2(0xc00005f900?, {0x311fe20?, 0x4?, 0x174b889?})
	/home/dvush/flashbots/code/builder-playground/main.go:145 +0x105
github.com/spf13/cobra.(*Command).execute(0x2667c20, {0x311fe20, 0x0, 0x0})
	/home/dvush/.local/share/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1015 +0xb02
github.com/spf13/cobra.(*Command).ExecuteC(0x2666e60)
	/home/dvush/.local/share/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1148 +0x465
github.com/spf13/cobra.(*Command).Execute(...)
	/home/dvush/.local/share/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1071
main.main()
	/home/dvush/flashbots/code/builder-playground/main.go:320 +0xa49

```

after:

```
Error: accepts 1 arg(s), received 0
Usage:
  playground debug probe <service> [flags]

Flags:
  -h, --help   help for probe

accepts 1 arg(s), received 0

```