### PR TITLE
Rename ServiceGen to Component for semantic clarity

### DIFF
--- a/docs/internals/writing_components.md
+++ b/docs/internals/writing_components.md
@@ -2,7 +2,7 @@
 
 Components are the fundamental computational units in Builder Playground. Each component represents one or more Docker containers that work together as a single logical service.
 
-A component is defined as a Go struct that implements the `ServiceGen` interface by providing an `Apply` method:
+A component is defined as a Go struct that implements the `Component` interface by providing an `Apply` method:
 
 ```go
 type RethEL struct {

--- a/playground/catalog.go
+++ b/playground/catalog.go
@@ -1,8 +1,8 @@
 package playground
 
-var Components = []ServiceGen{}
+var Components = []Component{}
 
-func register(component ServiceGen) {
+func register(component Component) {
 	Components = append(Components, component)
 }
 

--- a/playground/components_test.go
+++ b/playground/components_test.go
@@ -164,7 +164,7 @@ func newTestFramework(t *testing.T) *testFramework {
 	return &testFramework{t: t}
 }
 
-func (tt *testFramework) test(s ServiceGen, args []string) *Manifest {
+func (tt *testFramework) test(component Component, args []string) *Manifest {
 	t := tt.t
 
 	// use the name of the repo and the current timestamp to generate
@@ -189,7 +189,7 @@ func (tt *testFramework) test(s ServiceGen, args []string) *Manifest {
 		homeDir: filepath.Join(e2eTestDir, "artifacts"),
 	}
 
-	if recipe, ok := s.(Recipe); ok {
+	if recipe, ok := component.(Recipe); ok {
 		// We have to parse the flags since they are used to set the
 		// default values for the recipe inputs
 		err := recipe.Flags().Parse(args)
@@ -200,7 +200,7 @@ func (tt *testFramework) test(s ServiceGen, args []string) *Manifest {
 	}
 
 	svcManager := NewManifest(exCtx, o)
-	s.Apply(svcManager)
+	component.Apply(svcManager)
 
 	require.NoError(t, svcManager.Validate())
 

--- a/playground/manifest.go
+++ b/playground/manifest.go
@@ -149,7 +149,7 @@ func (b *BootnodeRef) Connect() string {
 	return ConnectEnode(b.Service, b.ID)
 }
 
-type ServiceGen interface {
+type Component interface {
 	Apply(manifest *Manifest)
 }
 
@@ -157,8 +157,8 @@ type ServiceReady interface {
 	Ready(service *Service) error
 }
 
-func (s *Manifest) AddService(srv ServiceGen) {
-	srv.Apply(s)
+func (s *Manifest) AddComponent(component Component) {
+	component.Apply(s)
 }
 
 func (s *Manifest) MustGetService(name string) *Service {
@@ -654,6 +654,6 @@ func ReadManifest(outputFolder string) (*Manifest, error) {
 
 func (svcManager *Manifest) RunContenderIfEnabled() {
 	if svcManager.ctx.Contender.Enabled {
-		svcManager.AddService(svcManager.ctx.Contender.Contender())
+		svcManager.AddComponent(svcManager.ctx.Contender.Contender())
 	}
 }

--- a/playground/recipe_buildernet.go
+++ b/playground/recipe_buildernet.go
@@ -41,7 +41,7 @@ func (b *BuilderNetRecipe) Apply(svcManager *Manifest) {
 	// Start with the L1Recipe manifest
 	b.l1Recipe.Apply(svcManager)
 
-	svcManager.AddService(&BuilderHub{})
+	svcManager.AddComponent(&BuilderHub{})
 
 	svcManager.RunContenderIfEnabled()
 }

--- a/playground/recipe_l1.go
+++ b/playground/recipe_l1.go
@@ -66,7 +66,7 @@ func (l *L1Recipe) Artifacts() *ArtifactsBuilder {
 var looksLikePortRegex = regexp.MustCompile(`^\d{2,5}$`)
 
 func (l *L1Recipe) Apply(svcManager *Manifest) {
-	svcManager.AddService(&RethEL{
+	svcManager.AddComponent(&RethEL{
 		UseRethForValidation: l.useRethForValidation,
 		UseNativeReth:        l.useNativeReth,
 	})
@@ -81,7 +81,7 @@ func (l *L1Recipe) Apply(svcManager *Manifest) {
 		// we are going to use the cl-proxy service to connect the beacon node to two builders
 		// one the 'el' builder and another one the remote one
 		elService = "cl-proxy"
-		svcManager.AddService(&ClProxy{
+		svcManager.AddComponent(&ClProxy{
 			PrimaryBuilder:   "el",
 			SecondaryBuilder: address,
 		})
@@ -98,11 +98,11 @@ func (l *L1Recipe) Apply(svcManager *Manifest) {
 		mevBoostNode = "mev-boost-relay"
 	}
 
-	svcManager.AddService(&LighthouseBeaconNode{
+	svcManager.AddComponent(&LighthouseBeaconNode{
 		ExecutionNode: elService,
 		MevBoostNode:  mevBoostNode,
 	})
-	svcManager.AddService(&LighthouseValidator{
+	svcManager.AddComponent(&LighthouseValidator{
 		BeaconNode: "beacon",
 	})
 
@@ -112,12 +112,12 @@ func (l *L1Recipe) Apply(svcManager *Manifest) {
 			mevBoostValidationServer = "el"
 		}
 
-		svcManager.AddService(&MevBoostRelay{
+		svcManager.AddComponent(&MevBoostRelay{
 			BeaconClient:     "beacon",
 			ValidationServer: mevBoostValidationServer,
 		})
 
-		svcManager.AddService(&MevBoost{
+		svcManager.AddComponent(&MevBoost{
 			RelayEndpoints: []string{"mev-boost-relay"},
 		})
 	} else {
@@ -126,7 +126,7 @@ func (l *L1Recipe) Apply(svcManager *Manifest) {
 		if l.useRethForValidation {
 			mevBoostValidationServer = "el"
 		}
-		svcManager.AddService(&MevBoostRelay{
+		svcManager.AddComponent(&MevBoostRelay{
 			BeaconClient:     "beacon",
 			ValidationServer: mevBoostValidationServer,
 		})

--- a/playground/recipe_opstack.go
+++ b/playground/recipe_opstack.go
@@ -74,11 +74,11 @@ func (o *OpRecipe) Artifacts() *ArtifactsBuilder {
 }
 
 func (o *OpRecipe) Apply(svcManager *Manifest) {
-	svcManager.AddService(&RethEL{})
-	svcManager.AddService(&LighthouseBeaconNode{
+	svcManager.AddComponent(&RethEL{})
+	svcManager.AddComponent(&LighthouseBeaconNode{
 		ExecutionNode: "el",
 	})
-	svcManager.AddService(&LighthouseValidator{
+	svcManager.AddComponent(&LighthouseValidator{
 		BeaconNode: "beacon",
 	})
 
@@ -87,7 +87,7 @@ func (o *OpRecipe) Apply(svcManager *Manifest) {
 	peers := []string{}
 
 	opGeth := &OpGeth{}
-	svcManager.AddService(opGeth)
+	svcManager.AddComponent(opGeth)
 
 	svcManager.ctx.Bootnode = &BootnodeRef{
 		Service: "op-geth",
@@ -96,11 +96,11 @@ func (o *OpRecipe) Apply(svcManager *Manifest) {
 
 	if o.externalBuilder == "op-reth" {
 		// Add a new op-reth service and connect it to Rollup-boost
-		svcManager.AddService(&OpReth{})
+		svcManager.AddComponent(&OpReth{})
 
 		externalBuilderRef = Connect("op-reth", "authrpc")
 	} else if o.externalBuilder == "op-rbuilder" {
-		svcManager.AddService(&OpRbuilder{
+		svcManager.AddComponent(&OpRbuilder{
 			Flashblocks: o.flashblocks,
 		})
 		externalBuilderRef = Connect("op-rbuilder", "authrpc")
@@ -117,7 +117,7 @@ func (o *OpRecipe) Apply(svcManager *Manifest) {
 
 	// Only enable bproxy if flashblocks is enabled (since flashblocks-rpc is the only service that needs it)
 	if o.flashblocks {
-		svcManager.AddService(&BProxy{
+		svcManager.AddComponent(&BProxy{
 			TargetAuthrpc:         externalBuilderRef,
 			Peers:                 peers,
 			Flashblocks:           o.flashblocks,
@@ -127,7 +127,7 @@ func (o *OpRecipe) Apply(svcManager *Manifest) {
 
 	// Only enable websocket-proxy if the flag is set
 	if o.enableWebsocketProxy {
-		svcManager.AddService(&WebsocketProxy{
+		svcManager.AddComponent(&WebsocketProxy{
 			Upstream: "rollup-boost",
 		})
 	}
@@ -144,7 +144,7 @@ func (o *OpRecipe) Apply(svcManager *Manifest) {
 			flashblocksBuilderRef = ConnectWs("bproxy", "flashblocks")
 		}
 
-		svcManager.AddService(&RollupBoost{
+		svcManager.AddComponent(&RollupBoost{
 			ELNode:                "op-geth",
 			Builder:               builderRef,
 			Flashblocks:           o.flashblocks,
@@ -161,20 +161,20 @@ func (o *OpRecipe) Apply(svcManager *Manifest) {
 			useWebsocketProxy = true
 		}
 
-		svcManager.AddService(&FlashblocksRPC{
+		svcManager.AddComponent(&FlashblocksRPC{
 			FlashblocksWSService: flashblocksWSService,
 			BaseOverlay:          o.baseOverlay,
 			UseWebsocketProxy:    useWebsocketProxy,
 		})
 	}
 
-	svcManager.AddService(&OpNode{
+	svcManager.AddComponent(&OpNode{
 		L1Node:   "el",
 		L1Beacon: "beacon",
 		L2Node:   elNode,
 	})
 
-	svcManager.AddService(&OpBatcher{
+	svcManager.AddComponent(&OpBatcher{
 		L1Node:             "el",
 		L2Node:             "op-geth",
 		RollupNode:         "op-node",
@@ -182,7 +182,7 @@ func (o *OpRecipe) Apply(svcManager *Manifest) {
 	})
 
 	if o.enableChainMonitor {
-		svcManager.AddService(&ChainMonitor{
+		svcManager.AddComponent(&ChainMonitor{
 			L1RPC:            "el",
 			L2BlockTime:      o.blockTime,
 			L2BuilderAddress: defaultL2BuilderAddress,


### PR DESCRIPTION
This PR addresses a naming inconsistency that has been causing confusion in the codebase.

Originally, ServiceGen represented a single Service (compute unit), which is where the name came from. However, in a previous PR, we evolved ServiceGen to align with the Recipe interface pattern, enabling it to produce multiple Service instances for better composability. This created a semantic mismatch:
* Service struct = a single compute unit (container/process)
* ServiceGen interface = a component that can generate one or more Service instances
* AddService(ServiceGen) = misleadingly named method that doesn't add a Service, but rather a generator/component

This PR does some renaming to provide better semantic clarity:
* ServiceGen → Component (a pod-like entity that produces one or more services)
* AddService() → AddComponent() (makes it clear you're adding a multi-service component)
* Service → unchanged (still represents a single compute unit)

