### PR TITLE
Fix bug updateTaskStatus panic with two calls

### DIFF
--- a/playground/local_runner.go
+++ b/playground/local_runner.go
@@ -189,7 +189,14 @@ func (d *LocalRunner) checkAndUpdateReadiness() {
 			}
 		}
 	}
-	close(d.allTasksReadyCh)
+
+	select {
+	case <-d.allTasksReadyCh:
+		// Channel is already closed, do nothing
+	default:
+		// Channel is not closed yet, close it
+		close(d.allTasksReadyCh)
+	}
 }
 
 func (d *LocalRunner) WaitForReady(ctx context.Context) error {

--- a/playground/local_runner_test.go
+++ b/playground/local_runner_test.go
@@ -97,3 +97,23 @@ func TestWaitForReady_Success(t *testing.T) {
 	err = runner.WaitForReady(waitCtx)
 	require.NoError(t, err)
 }
+
+func TestCheckAndUpdateReadiness_MultipleCallsNoPanic(t *testing.T) {
+	manifest := &Manifest{
+		Services: []*Service{
+			{Name: "test-service"},
+		},
+	}
+
+	cfg := &RunnerConfig{
+		Manifest: manifest,
+	}
+	runner, err := NewLocalRunner(cfg)
+	require.NoError(t, err)
+
+	runner.updateTaskStatus("test-service", TaskStatusStarted)
+
+	require.NotPanics(t, func() {
+		runner.checkAndUpdateReadiness()
+	})
+}


### PR DESCRIPTION
If checkAndUpdateReadiness is called twice it can cause a panic.