### PR TITLE
Claude CI fixes

### DIFF
--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -5,7 +5,7 @@ on:
   pull_request_review_comment:
     types: [created]
   pull_request:
-    types: [opened, synchronize]  # opened = new PR, synchronize = new commits pushed
+    types: [opened, synchronize] # opened = new PR, synchronize = new commits pushed
   issues:
     types: [opened, assigned]
 
@@ -14,35 +14,104 @@ permissions:
   pull-requests: write
   issues: write
   id-token: write
+  actions: read # Required for Claude to read CI results on PRs
 
 jobs:
-  # Interactive mode - responds to @claude mentions
-  claude-response:
-    if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: anthropics/claude-code-action@v1
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: |
-            --model opus
-
-  # Automation mode - auto-review new PRs
+  # Auto-review for same-repo PRs
   claude-review:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          track_progress: true # ✨ Enables tracking comments
+          claude_args: |
+            --model opus \
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Act as a code reviewer for this pull request. Focus your review on:
+            - Overall code quality and adherence to best practices
+            - Possible bugs, edge cases, or logical errors
+            - Security concerns or unsafe patterns
+            - Performance characteristics and potential optimizations
+
+            Provide thorough, actionable feedback, and use inline comments for any line-specific issues you identify.
+
+            Note: The PR branch is already checked out in the current working directory.
+
+            Use `gh pr comment` for summary or top-level feedback on the PR.
+            Use `mcp__github_inline_comment__create_inline_comment` to annotate specific code issues inline.
+            Only post GitHub comments - don't submit review text as messages.
+            Use top-level comments for general observations or praise.
+
+  # Manual review triggered by "@claude review" comment (works for forks too)
+  claude-manual-review:
+    if: |
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '@claude review')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Checkout PR branch
+        run: gh pr checkout ${{ github.event.issue.number }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          track_progress: true # ✨ Enables tracking comments
+          claude_args: |
+            --model opus \
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.issue.number }}
+
+            Act as a code reviewer for this pull request. Focus your review on:
+            - Overall code quality and adherence to best practices
+            - Possible bugs, edge cases, or logical errors
+            - Security concerns or unsafe patterns
+            - Performance characteristics and potential optimizations
+
+            Provide thorough, actionable feedback, and use inline comments for any line-specific issues you identify.
+
+            Note: The PR branch is already checked out in the current working directory.
+
+            Use `gh pr comment` for summary or top-level feedback on the PR.
+            Use `mcp__github_inline_comment__create_inline_comment` to annotate specific code issues inline.
+            Only post GitHub comments - don't submit review text as messages.
+            Use top-level comments for general observations or praise.
+
+  # General interactive mode - responds to @claude mentions (but NOT review requests on PRs)
+  claude-response:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '@claude review')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '@claude review')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && !contains(github.event.review.body, '@claude review')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Checkout PR branch (if on a PR)
+        if: github.event.issue.pull_request || github.event.pull_request
+        run: gh pr checkout ${{ github.event.issue.number || github.event.pull_request.number }}
+        env:
+          GH_TOKEN: ${{ github.token }}
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
-            --model opus
-          prompt: |
-            Review this PR. Focus on:
-            - Correctness and potential bugs
-            - Code clarity and maintainability
-            - Any security concerns
-
-            Be concise. Only comment if you have substantive feedback.
+            --model opus \
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr create:*),Bash(git checkout:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git branch:*),Edit,Write,MultiEdit"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,3 +77,17 @@ Available recipes: L1 (`recipe_l1.go`), OpStack (`recipe_opstack.go`), BuilderNe
 2. Implement: Name, Description, Flags, Artifacts, Apply, Output
 3. Register in `main.go` recipes slice
 4. Run `make generate-docs` to update documentation
+
+
+## Implementation Workflow
+
+IMPORTANT: When asked to implement something, always follow through completely:
+1.. Create a feature branch
+- based on the latest `main` branch
+- use descriptive branch names like `claude/issue-123-add-feature`
+2. Make the code changes
+3. Commit the changes
+4. Push the branch
+5. Create the PR with `gh pr create --title "..." --body "..."` and reference the issue number in the PR description (e.g., "Closes #123")
+
+Do NOT stop at providing links — complete the entire workflow automatically.


### PR DESCRIPTION
This change updates the Claude workflow to do the following (all flows tested):
1. Auto-review every internal PR (which originates from the repo, external repos don’t have access to the keys for security reasaons)
2. You can trigger a PR review with `@claude review` on any PR
3. It will automatically respond to any message including `@claude` on issues and PRs, which can also contribute PRs (i.e. `@claude add XXX to AGENTS.md`)