### PR TITLE
Add port subcommand for querying service host ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,26 @@ $ builder-playground inspect op-geth authrpc
 
 This command starts a `tcpflow` container in the same network interface as the service and captures the traffic to the specified port.
 
+## Port
+
+Look up the host port for a service:
+
+```bash
+$ builder-playground port el http
+8545
+```
+
+Use `--list` to show all available ports:
+
+```bash
+$ builder-playground port el --list
+authrpc: 8551
+http: 8545
+metrics: 9091
+rpc: 30303
+ws: 8546
+```
+
 ## Stop
 
 Stop local playground sessions and keep all Docker resources (containers/volumes/networks):

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4 v1.1.3
 	golang.org/x/sync v0.18.0
 	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -176,7 +177,6 @@ require (
 	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/cenkalti/backoff.v1 v1.1.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gotest.tools/v3 v3.5.2 // indirect
 	k8s.io/apimachinery v0.30.4 // indirect
 	k8s.io/client-go v0.30.4 // indirect

--- a/playground/cmd_port.go
+++ b/playground/cmd_port.go
@@ -1,0 +1,103 @@
+package playground
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/docker/docker/api/types/container"
+)
+
+// GetServicePort returns the host port for a given service and port name.
+// If portName is empty, returns a formatted string listing all available ports.
+// If session is empty and there's exactly one session, it uses that session.
+func GetServicePort(session, serviceName, portName string) (string, error) {
+	client, err := newDockerClient()
+	if err != nil {
+		return "", fmt.Errorf("failed to create docker client: %w", err)
+	}
+	defer client.Close()
+
+	if session == "" {
+		sessions, err := GetLocalSessions()
+		if err != nil {
+			return "", fmt.Errorf("failed to get sessions: %w", err)
+		}
+		if len(sessions) == 0 {
+			return "", fmt.Errorf("no running sessions found")
+		}
+		if len(sessions) > 1 {
+			return "", fmt.Errorf("multiple sessions found, please specify a session name: %v", sessions)
+		}
+		session = sessions[0]
+	}
+
+	containers, err := client.ContainerList(context.Background(), container.ListOptions{
+		All: true,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to list containers: %w", err)
+	}
+
+	for _, c := range containers {
+		if c.Labels["playground"] != "true" ||
+			c.Labels["playground.session"] != session ||
+			c.Labels["com.docker.compose.service"] != serviceName {
+			continue
+		}
+
+		// Build a map of port name -> host port
+		portMap := make(map[string]int)
+		for label, containerPortStr := range c.Labels {
+			if !strings.HasPrefix(label, "port.") {
+				continue
+			}
+			name := strings.TrimPrefix(label, "port.")
+			containerPort, err := strconv.Atoi(containerPortStr)
+			if err != nil {
+				continue
+			}
+			for _, p := range c.Ports {
+				if int(p.PrivatePort) == containerPort && p.PublicPort != 0 {
+					portMap[name] = int(p.PublicPort)
+					break
+				}
+			}
+		}
+
+		if portName == "" {
+			if len(portMap) == 0 {
+				return "", fmt.Errorf("no ports found for service '%s'", serviceName)
+			}
+			var names []string
+			for name := range portMap {
+				names = append(names, name)
+			}
+			sort.Strings(names)
+
+			var lines []string
+			for _, name := range names {
+				lines = append(lines, fmt.Sprintf("%s: %d", name, portMap[name]))
+			}
+			return strings.Join(lines, "\n"), nil
+		}
+
+		if hostPort, ok := portMap[portName]; ok {
+			return fmt.Sprintf("%d", hostPort), nil
+		}
+
+		var availablePorts []string
+		for name := range portMap {
+			availablePorts = append(availablePorts, name)
+		}
+		sort.Strings(availablePorts)
+		if len(availablePorts) > 0 {
+			return "", fmt.Errorf("port '%s' not found for service '%s'. Available ports: %v", portName, serviceName, availablePorts)
+		}
+		return "", fmt.Errorf("port '%s' not found for service '%s'", portName, serviceName)
+	}
+
+	return "", fmt.Errorf("service '%s' not found in session '%s'", serviceName, session)
+}


### PR DESCRIPTION
Adds `playground port [session] <service> <port-name>` command that returns the host port for a running service. When only one session is running, the session name can be omitted.

Use --list flag to show all available ports for a service.

Examples:
  playground port el http        # returns 8545
  playground port el --list      # lists all ports
  playground port my-session el http
  
  
I find it very useful, because you can integrate your other scripts with playground using this tool. For example, I would write
`export RPC_URL=$(builder-playground port op-geth http)`
and it would work after remapping would change