### PR TITLE
Fix the ci-release target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,8 +63,8 @@ ci-release:
 		--rm \
 		-e CGO_ENABLED=1 \
 		-e GITHUB_TOKEN="$(GITHUB_TOKEN)" \
-		-v `pwd`:/go/src/github.com/flashbots/builder-playground \
-		-w /go/src/github.com/flashbots/builder-playground \
+		-v `pwd`:/workspace \
+		-w /workspace \
 		ghcr.io/goreleaser/goreleaser-cross:v1.21.12 \
 		release --clean --auto-snapshot
 


### PR DESCRIPTION
Attempt to fix failing v0.3.0 release:
```
WARNING: Error loading config file: /root/.docker/config.json: : read /root/.docker/config.json: is a directory
WARNING! Your password will be stored unencrypted in /root/.docker/config.json.
Configure a credential helper to remove this warning. See
https://docs.docker.com/engine/reference/commandline/login/#credential-stores

Error saving credentials: rename /root/.docker/config.json3144492920 /root/.docker/config.json: file exists
make: *** [Makefile:62: ci-release] Error 1
Error: Process completed with exit code 2.
```

- Removing Docker config management since it is not necessary for this release
- Simplifying workspace dir setup