### PR TITLE
feat: generate docker-compose.yaml during dry-run mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -642,10 +642,6 @@ func runIt(recipe playground.Recipe) error {
 		}
 	}
 
-	if dryRun {
-		return nil
-	}
-
 	if err := svcManager.ApplyOverrides(overrides); err != nil {
 		return err
 	}
@@ -673,6 +669,15 @@ func runIt(recipe playground.Recipe) error {
 	dockerRunner, err := playground.NewLocalRunner(cfg)
 	if err != nil {
 		return fmt.Errorf("failed to create docker runner: %w", err)
+	}
+
+	// Generate docker-compose.yaml file (needed for both dry-run and normal execution)
+	if err := dockerRunner.GenerateDockerComposeFile(); err != nil {
+		return fmt.Errorf("failed to generate docker-compose file: %w", err)
+	}
+
+	if dryRun {
+		return nil
 	}
 
 	ctx := mainctx.Get()


### PR DESCRIPTION
Issue to address: https://github.com/flashbots/builder-playground/issues/231

### Summary
The `--dry-run` flag now generates the `docker-compose.yaml` file in the output folder, allowing users to inspect the Docker configuration without starting services.

### Changes
- Added [GenerateDockerComposeFile()](cci:1://file:///Users/alexey/github/builder-playground/playground/local_runner.go:209:0-226:1) method to [LocalRunner](cci:2://file:///builder-playground/playground/local_runner.go:41:0-63:1) for independent docker-compose generation
- Added `skipImageValidation` flag to skip Docker daemon checks during dry-run
- Moved docker-compose generation before dry-run exit in [main.go](cci:7://file:///builder-playground/main.go:0:0-0:0)
- Removed duplicate generation from [Run()](cci:1://file:///builder-playground/playground/local_runner.go:1064:0-1107:1) method

### Testing
- Verified with `./builder-playground start l1 --dry-run`
- Verified with `./builder-playground start opstack --dry-run`
- All unit tests pass (except Docker-dependent integration test)