### PR TITLE
Use home dir for artifacts in tests

### DIFF
--- a/playground/components_test.go
+++ b/playground/components_test.go
@@ -200,9 +200,12 @@ func (tt *testFramework) test(component ComponentGen, args []string) *Manifest {
 		t.Fatal(err)
 	}
 
+	homeDir, err := GetHomeDir()
+	require.NoError(t, err)
+
 	o := &output{
 		dst:     e2eTestDir,
-		homeDir: filepath.Join(e2eTestDir, "artifacts"),
+		homeDir: homeDir,
 	}
 
 	exCtx := &ExContext{


### PR DESCRIPTION
This PR uses the home directory to retrieve the artifacts from tests so that they are not downloaded every time for each tests that requires them.