### PR TITLE
Fix base-overlay entrypoint path: base-reth-node → base-client

### DIFF
--- a/playground/components.go
+++ b/playground/components.go
@@ -130,7 +130,7 @@ func (f *FlashblocksRPC) Apply(ctx *ExContext) *Component {
 		service = component.NewService("flashblocks-rpc").
 			WithImage("ghcr.io/base/node-reth-dev").
 			WithTag("main").
-			WithEntrypoint("/app/base-reth-node").
+			WithEntrypoint("/app/base-client").
 			WithArgs(
 				"node",
 				"--websocket-url", websocketURL,


### PR DESCRIPTION
## Summary
- Fixes container startup failure when using `--base-overlay` with the `ghcr.io/base/node-reth-dev` image
- The base/base repository renamed the binary from `base-reth-node` to `base-client` in commit [02cd27a](https://github.com/base/base/commit/02cd27a)

## Test plan
- [x] Run `builder-playground cook opstack --base-overlay` and verify the flashblocks-rpc container starts successfully