### PR TITLE
Add validate command for recipe pre-flight checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,16 @@ rpc: 30303
 ws: 8546
 ```
 
+## Validate
+
+Check a recipe for errors before running:
+
+```bash
+$ builder-playground validate my-recipe.yaml
+```
+
+This validates dependencies, host paths, port conflicts, and service name uniqueness without starting any containers. Useful for catching configuration errors early, especially with custom recipes.
+
 ## Stop
 
 Stop local playground sessions and keep all Docker resources (containers/volumes/networks):

--- a/playground/cmd_validate.go
+++ b/playground/cmd_validate.go
@@ -1,0 +1,174 @@
+package playground
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// ValidationResult holds the results of recipe validation
+type ValidationResult struct {
+	Errors   []string
+	Warnings []string
+}
+
+func (v *ValidationResult) AddError(format string, args ...interface{}) {
+	v.Errors = append(v.Errors, fmt.Sprintf(format, args...))
+}
+
+func (v *ValidationResult) AddWarning(format string, args ...interface{}) {
+	v.Warnings = append(v.Warnings, fmt.Sprintf(format, args...))
+}
+
+func (v *ValidationResult) IsValid() bool {
+	return len(v.Errors) == 0
+}
+
+// ValidateRecipe validates a recipe without starting it
+func ValidateRecipe(recipe Recipe, baseRecipes []Recipe) *ValidationResult {
+	result := &ValidationResult{}
+
+	// For YAML recipes, do additional validation
+	if yamlRecipe, ok := recipe.(*YAMLRecipe); ok {
+		validateYAMLRecipe(yamlRecipe, baseRecipes, result)
+	}
+
+	// Build a minimal manifest to validate structure
+	exCtx := &ExContext{
+		LogLevel: LevelInfo,
+		Contender: &ContenderContext{
+			Enabled: false,
+		},
+	}
+
+	component := recipe.Apply(exCtx)
+	manifest := NewManifest("validation-test", component)
+
+	// Validate service names are unique
+	validateUniqueServiceNames(manifest, result)
+
+	// Validate port configurations
+	validatePorts(manifest, result)
+
+	// Validate dependencies
+	validateDependencies(manifest, result)
+
+	// Validate host paths exist (if specified)
+	validateHostPaths(manifest, result)
+
+	return result
+}
+
+func validateYAMLRecipe(recipe *YAMLRecipe, baseRecipes []Recipe, result *ValidationResult) {
+	// Check base recipe exists
+	baseFound := false
+	for _, r := range baseRecipes {
+		if r.Name() == recipe.config.Base {
+			baseFound = true
+			break
+		}
+	}
+	if !baseFound {
+		result.AddError("base recipe '%s' not found", recipe.config.Base)
+	}
+
+	// Check for potential component/service name mismatches
+	if recipe.config.Recipe != nil {
+		for componentName, componentConfig := range recipe.config.Recipe {
+			if componentConfig == nil {
+				continue
+			}
+
+			// Warn about common naming issues
+			if componentConfig.Remove {
+				// Check if trying to remove a component that might not exist
+				if strings.Contains(componentName, "-") {
+					result.AddWarning("removing component '%s' - verify this matches the base recipe component name", componentName)
+				}
+			}
+
+			if componentConfig.Services != nil {
+				for serviceName, serviceConfig := range componentConfig.Services {
+					if serviceConfig == nil {
+						continue
+					}
+					if serviceConfig.Remove {
+						result.AddWarning("removing service '%s' from component '%s' - verify names match base recipe", serviceName, componentName)
+					}
+				}
+			}
+		}
+	}
+}
+
+func validateUniqueServiceNames(manifest *Manifest, result *ValidationResult) {
+	seen := make(map[string]bool)
+	for _, svc := range manifest.Services {
+		if seen[svc.Name] {
+			result.AddError("duplicate service name: %s", svc.Name)
+		}
+		seen[svc.Name] = true
+	}
+}
+
+func validatePorts(manifest *Manifest, result *ValidationResult) {
+	// Check for port number conflicts across services
+	portUsage := make(map[int][]string) // port number -> service names
+
+	for _, svc := range manifest.Services {
+		for _, port := range svc.Ports {
+			portUsage[port.Port] = append(portUsage[port.Port], svc.Name)
+		}
+	}
+
+	for portNum, services := range portUsage {
+		if len(services) > 1 {
+			result.AddWarning("port %d used by multiple services: %s (may conflict if running on same host)", portNum, strings.Join(services, ", "))
+		}
+	}
+}
+
+func validateDependencies(manifest *Manifest, result *ValidationResult) {
+	serviceNames := make(map[string]bool)
+	for _, svc := range manifest.Services {
+		serviceNames[svc.Name] = true
+	}
+
+	for _, svc := range manifest.Services {
+		for _, dep := range svc.DependsOn {
+			depName := dep.Name
+
+			// Handle healthmon sidecars
+			depName = strings.TrimSuffix(depName, "_readycheck")
+
+			// Handle component.service format (e.g., "merger.merger-builder")
+			if strings.Contains(depName, ".") {
+				parts := strings.SplitN(depName, ".", 2)
+				if len(parts) == 2 {
+					depName = parts[1] // Use just the service name
+				}
+			}
+
+			if !serviceNames[depName] && !serviceNames[dep.Name] {
+				result.AddError("service '%s' depends on unknown service '%s'", svc.Name, dep.Name)
+			}
+		}
+
+		// Check NodeRefs
+		for _, ref := range svc.NodeRefs {
+			if !serviceNames[ref.Service] {
+				result.AddError("service '%s' references unknown service '%s'", svc.Name, ref.Service)
+			}
+		}
+	}
+}
+
+func validateHostPaths(manifest *Manifest, result *ValidationResult) {
+	for _, svc := range manifest.Services {
+		if svc.HostPath != "" {
+			if _, err := os.Stat(svc.HostPath); os.IsNotExist(err) {
+				result.AddError("service '%s' host_path does not exist: %s", svc.Name, svc.HostPath)
+			}
+		}
+	}
+}


### PR DESCRIPTION
- New `playground validate <recipe>` command
- Validates dependencies exist
- Validates host paths exist
- Detects port conflicts
- Checks service name uniqueness

This change has been a major QoL improvement when running custom recipes. I must have wasted an hour of effort before deciding to write this, and it has unblocked me within 5 minutes.

To test the (AI-generated) changes:

**1. Catch bad recipe before running**

```bash
cat > /tmp/broken.yaml << 'EOF'
base: l1
recipe:
  test:
    services:
      my-service:
        host_path: "/nonexistent/path/binary"
        depends_on:
          - "nonexistent-service:healthy"
EOF
```

| Before | After |
|--------|-------|
| `playground start /tmp/broken.yaml` - starts Docker containers, waits for dependencies, eventually fails with confusing timeout or runtime error after wasting time | `playground validate /tmp/broken.yaml` - immediately shows: `host_path does not exist: /nonexistent/path/binary` and `depends on unknown service 'nonexistent-service'` |

**2. Validate before deploying**

```bash
# Check a recipe is valid before committing/deploying
playground validate l1
```

| Before | After |
|--------|-------|
| No way to check - must run `playground start` and wait for errors | `Validation passed!` - confirms recipe is valid without starting anything |

**3. Catch typos in service references**

```bash
cat > /tmp/typo.yaml << 'EOF'
base: l1
recipe:
  custom:
    services:
      my-service:
        image: alpine
        tag: latest
        depends_on:
          - "el-typo:healthy"
EOF
```

| Before | After |
|--------|-------|
| `playground start` hangs waiting for `el-typo` service that doesn't exist | `playground validate` catches it: `depends on unknown service 'el-typo'` |
