### PR TITLE
CLI flags for custom recipes and graceful shutdown

### DIFF
--- a/main.go
+++ b/main.go
@@ -475,29 +475,6 @@ func main() {
 	// Set the embedded custom recipes filesystem for the playground package
 	playground.CustomRecipesFS = customRecipesFS
 
-	// Add common flags to startCmd for YAML recipe files
-	startCmd.Flags().BoolVar(&keepFlag, "keep", false, "keep the containers and resources after the session is stopped")
-	startCmd.Flags().StringVar(&outputFlag, "output", "", "Output folder for the artifacts")
-	startCmd.Flags().BoolVar(&watchdog, "watchdog", false, "enable watchdog")
-	startCmd.Flags().StringArrayVar(&withOverrides, "override", []string{}, "override a service's config")
-	startCmd.Flags().BoolVar(&dryRun, "dry-run", false, "dry run the recipe")
-	startCmd.Flags().BoolVar(&dryRun, "mise-en-place", false, "mise en place mode")
-	startCmd.Flags().Uint64Var(&genesisDelayFlag, "genesis-delay", playground.MinimumGenesisDelay, "")
-	startCmd.Flags().BoolVar(&interactive, "interactive", false, "interactive mode")
-	startCmd.Flags().DurationVar(&timeout, "timeout", 0, "")
-	startCmd.Flags().StringVar(&logLevelFlag, "log-level", "info", "log level")
-	startCmd.Flags().BoolVar(&bindExternal, "bind-external", false, "bind host ports to external interface")
-	startCmd.Flags().BoolVar(&withPrometheus, "with-prometheus", false, "whether to gather the Prometheus metrics")
-	startCmd.Flags().StringVar(&networkName, "network", "", "network name")
-	startCmd.Flags().Var(&labels, "labels", "list of labels to apply to the resources")
-	startCmd.Flags().BoolVar(&disableLogs, "disable-logs", false, "disable logs")
-	startCmd.Flags().StringVar(&platform, "platform", "", "docker platform to use")
-	startCmd.Flags().BoolVar(&contenderEnabled, "contender", false, "spam nodes with contender")
-	startCmd.Flags().StringArrayVar(&contenderArgs, "contender.arg", []string{}, "add/override contender CLI flags")
-	startCmd.Flags().StringVar(&contenderTarget, "contender.target", "", "override the node that contender spams")
-	startCmd.Flags().BoolVar(&detached, "detached", false, "Detached mode: Run the recipes in the background")
-	startCmd.Flags().StringArrayVar(&prefundedAccounts, "prefunded-accounts", []string{}, "Fund this account in addition to static prefunded accounts")
-
 	// Helper to add common recipe flags to a command
 	addCommonRecipeFlags := func(cmd *cobra.Command) {
 		cmd.Flags().BoolVar(&keepFlag, "keep", false, "keep the containers and resources after the session is stopped")
@@ -523,50 +500,53 @@ func main() {
 		cmd.Flags().StringArrayVar(&prefundedAccounts, "prefunded-accounts", []string{}, "Fund this account in addition to static prefunded accounts")
 	}
 
-	for _, recipe := range recipes {
+	// Add common flags to startCmd for YAML recipe files
+	addCommonRecipeFlags(startCmd)
+
+	// Load custom recipes first to get their flags and descriptions
+	customRecipeNames, _ := playground.GetEmbeddedCustomRecipes()
+	customRecipeDisplayNames := make(map[playground.Recipe]string)
+	var customRecipes []playground.Recipe
+
+	for _, crName := range customRecipeNames {
+		customRecipe, cleanup, err := playground.LoadCustomRecipe(crName, recipes)
+		if err != nil {
+			continue // Skip invalid custom recipes
+		}
+		customRecipes = append(customRecipes, customRecipe)
+		customRecipeDisplayNames[customRecipe] = crName
+		cleanup() // Clean up temp dir from flag discovery
+	}
+
+	// Register all recipes (built-in and custom) as subcommands
+	for _, recipe := range append(recipes, customRecipes...) {
+		recipe := recipe // capture loop variable
+		recipeName := recipe.Name()
+		customRecipeName, isCustom := customRecipeDisplayNames[recipe]
+		if isCustom {
+			recipeName = customRecipeName
+		}
+
 		recipeCmd := &cobra.Command{
-			Use:   recipe.Name(),
+			Use:   recipeName,
 			Short: recipe.Description(),
 			RunE: func(cmd *cobra.Command, args []string) error {
 				cmd.SilenceUsage = true
+				if isCustom {
+					// Custom recipes need to be reloaded when actually running
+					actualRecipe, cleanupRun, err := playground.LoadCustomRecipe(customRecipeName, recipes)
+					if err != nil {
+						return err
+					}
+					defer cleanupRun()
+					return runIt(actualRecipe)
+				}
 				return runIt(recipe)
 			},
 		}
 		recipeCmd.Flags().AddFlagSet(recipe.Flags())
 		addCommonRecipeFlags(recipeCmd)
 		startCmd.AddCommand(recipeCmd)
-	}
-
-	// Register custom recipes as subcommands with their flags
-	customRecipeNames, _ := playground.GetEmbeddedCustomRecipes()
-	for _, crName := range customRecipeNames {
-		customRecipeName := crName // capture loop variable
-		// Load recipe just to get flags and description
-		customRecipe, cleanup, err := playground.LoadCustomRecipe(customRecipeName, recipes)
-		if err != nil {
-			continue // Skip invalid custom recipes
-		}
-		recipeFlags := customRecipe.Flags()
-		recipeDesc := customRecipe.Description()
-		cleanup() // Clean up temp dir from flag discovery
-
-		customCmd := &cobra.Command{
-			Use:   customRecipeName,
-			Short: recipeDesc,
-			RunE: func(cmd *cobra.Command, args []string) error {
-				// Load the recipe again when actually running
-				recipe, cleanupRun, err := playground.LoadCustomRecipe(customRecipeName, recipes)
-				if err != nil {
-					return err
-				}
-				defer cleanupRun()
-				cmd.SilenceUsage = true
-				return runIt(recipe)
-			},
-		}
-		customCmd.Flags().AddFlagSet(recipeFlags)
-		addCommonRecipeFlags(customCmd)
-		startCmd.AddCommand(customCmd)
 	}
 
 	rootCmd.AddCommand(startCmd)

--- a/utils/mainctx/context.go
+++ b/utils/mainctx/context.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"log/slog"
 	"os"
-	"os/exec"
 	"os/signal"
 	"syscall"
 )
@@ -23,37 +22,10 @@ func init() {
 		syscall.SIGTERM,
 		syscall.SIGQUIT)
 	go func() {
-		sigCount := 0
-		for sig := range sigCh {
-			sigCount++
-			if sigCount == 1 {
-				slog.Warn("received signal, shutting down gracefully... (interrupt 2 more times to force kill)", "signal", sig)
-				cancel()
-			} else if sigCount == 2 {
-				slog.Warn("received signal again (interrupt 1 more time to force kill)", "signal", sig)
-			} else if sigCount >= 3 {
-				slog.Warn("force killing containers and exiting...")
-				forceKillContainers()
-				os.Exit(1)
-			}
-		}
+		sig := <-sigCh
+		slog.Warn("received signal", "signal", sig)
+		cancel()
 	}()
-}
-
-// forceKillContainers kills all playground Docker containers
-func forceKillContainers() {
-	// Find all playground containers
-	cmd := exec.Command("docker", "ps", "-q", "--filter", "label=playground=true")
-	output, err := cmd.Output()
-	if err != nil || len(output) == 0 {
-		return
-	}
-	// Kill them forcefully
-	killCmd := exec.Command("docker", "kill", "--signal", "KILL")
-	killCmd.Args = append(killCmd.Args, string(output))
-	// Use shell to handle the container IDs
-	shellCmd := exec.Command("sh", "-c", "docker ps -q --filter label=playground=true | xargs -r docker kill")
-	_ = shellCmd.Run()
 }
 
 // Get returns a context that is aware of the interruption/termination signals received by the process.


### PR DESCRIPTION
- Register custom recipes as `playground start <name>` subcommands. This allows use of arguments with custom recipies, for example `--use-native-reth`

To test the (AI-generated) changes:
* Run any custom recipe with flags, without this PR it simply does not work