### PR TITLE
More forceful session stop on three interrupts

### DIFF
--- a/main.go
+++ b/main.go
@@ -675,6 +675,11 @@ func runIt(recipe playground.Recipe) error {
 		return fmt.Errorf("failed to create docker runner: %w", err)
 	}
 
+	// Register force kill handler for this session (triggered on 3rd interrupt)
+	mainctx.RegisterForceKillHandler(func() {
+		playground.ForceKillSession(sessionID)
+	})
+
 	ctx := mainctx.Get()
 
 	slog.Info("Starting services... ⏳", "session-id", svcManager.ID)

--- a/playground/local_runner.go
+++ b/playground/local_runner.go
@@ -31,7 +31,10 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-const defaultNetworkName = "ethplayground"
+const (
+	defaultNetworkName  = "ethplayground"
+	stopGracePeriodSecs = 30
+)
 
 // LocalRunner is a component that runs the services from the manifest on the local host machine.
 // By default, it uses docker and docker compose to run all the services.
@@ -274,6 +277,13 @@ func StopSession(id string, keepResources bool) error {
 	}
 
 	return nil
+}
+
+// ForceKillSession stops all containers for a session with a short grace period (SIGTERM, wait, SIGKILL)
+func ForceKillSession(id string) {
+	cmd := exec.Command("sh", "-c",
+		fmt.Sprintf("docker ps -q --filter label=playground.session=%s | xargs -r docker stop -t %d", id, stopGracePeriodSecs))
+	_ = cmd.Run()
 }
 
 func GetLocalSessions() ([]string, error) {
@@ -554,8 +564,9 @@ func (d *LocalRunner) toDockerComposeService(s *Service) (map[string]interface{}
 		// Add volume mount for the output directory
 		"volumes": volumesInLine,
 		// Add the ethereum network
-		"networks": []string{d.config.NetworkName},
-		"labels":   labels,
+		"networks":          []string{d.config.NetworkName},
+		"labels":            labels,
+		"stop_grace_period": fmt.Sprintf("%ds", stopGracePeriodSecs),
 	}
 
 	if d.config.Platform != "" {

--- a/utils/mainctx/context.go
+++ b/utils/mainctx/context.go
@@ -9,9 +9,16 @@ import (
 )
 
 var (
-	sigCh       = make(chan os.Signal, 1)
-	sigAwareCtx context.Context
+	sigCh            = make(chan os.Signal, 1)
+	sigAwareCtx      context.Context
+	forceKillHandler func()
 )
+
+// RegisterForceKillHandler sets a callback that will be invoked on the third interrupt signal.
+// This allows session-specific cleanup (e.g., killing only containers from current session).
+func RegisterForceKillHandler(handler func()) {
+	forceKillHandler = handler
+}
 
 func init() {
 	var cancel context.CancelFunc
@@ -22,9 +29,22 @@ func init() {
 		syscall.SIGTERM,
 		syscall.SIGQUIT)
 	go func() {
-		sig := <-sigCh
-		slog.Warn("received signal", "signal", sig)
-		cancel()
+		sigCount := 0
+		for sig := range sigCh {
+			sigCount++
+			if sigCount == 1 {
+				slog.Warn("received signal, shutting down gracefully... (interrupt 2 more times to force kill)", "signal", sig)
+				cancel()
+			} else if sigCount == 2 {
+				slog.Warn("received signal again (interrupt 1 more time to force kill)", "signal", sig)
+			} else if sigCount >= 3 {
+				slog.Warn("force killing containers and exiting...")
+				if forceKillHandler != nil {
+					forceKillHandler()
+				}
+				os.Exit(1)
+			}
+		}
 	}()
 }
 


### PR DESCRIPTION
If a service never becomes healthy (for example a dependency crashed), users have to manually clean up containers and processes. This change allows forceful shutdown with automatic clean up.

AI-generated.