### PR TITLE
feat: host_path support in recipes

### DIFF
--- a/playground/local_runner.go
+++ b/playground/local_runner.go
@@ -632,6 +632,11 @@ func (d *LocalRunner) toDockerComposeService(s *Service) (map[string]interface{}
 	// create the bind volumes
 	var createdVolumes []string
 	for localPath, volume := range s.VolumesMapped {
+		if volume.HostPath != "" {
+			volumes[volume.HostPath] = localPath
+			continue
+		}
+
 		dockerVolumeName := d.createVolumeName(s.Name, volume.Name)
 
 		if volume.IsLocal {

--- a/playground/manifest.go
+++ b/playground/manifest.go
@@ -453,8 +453,9 @@ type Service struct {
 }
 
 type VolumeMapped struct {
-	Name    string
-	IsLocal bool
+	Name     string
+	IsLocal  bool
+	HostPath string
 }
 
 type DependsOnCondition string
@@ -603,6 +604,16 @@ func (s *Service) WithVolume(name, localPath string, isLocalTri ...bool) *Servic
 	s.VolumesMapped[localPath] = &VolumeMapped{
 		Name:    name,
 		IsLocal: isLocal,
+	}
+	return s
+}
+
+func (s *Service) WithHostVolume(hostPath, containerPath string) *Service {
+	if s.VolumesMapped == nil {
+		s.VolumesMapped = make(map[string]*VolumeMapped)
+	}
+	s.VolumesMapped[containerPath] = &VolumeMapped{
+		HostPath: hostPath,
 	}
 	return s
 }

--- a/playground/recipe_yaml.go
+++ b/playground/recipe_yaml.go
@@ -572,7 +572,7 @@ func yamlReleaseToRelease(cfg *YAMLReleaseConfig) *release {
 	}
 }
 
-// applyFilesToService maps files to a service
+// applyVolumesToService maps volumes to a service
 func applyVolumesToService(svc *Service, volumes map[string]*YAMLVolumeMappedConfig) {
 	for containerPath, volumeMapping := range volumes {
 		if volumeMapping.HostPath != "" {

--- a/playground/recipe_yaml.go
+++ b/playground/recipe_yaml.go
@@ -116,8 +116,9 @@ type YAMLServiceConfig struct {
 }
 
 type YAMLVolumeMappedConfig struct {
-	Name    string `yaml:"name"`
-	IsLocal bool   `yaml:"is_local"`
+	Name     string `yaml:"name"`
+	IsLocal  bool   `yaml:"is_local"`
+	HostPath string `yaml:"host_path"`
 }
 
 // YAMLReleaseConfig specifies a GitHub release to download
@@ -481,9 +482,7 @@ func applyServiceOverrides(svc *Service, config *YAMLServiceConfig, root *Compon
 		applyFilesToService(svc, config.Files)
 	}
 	if config.Volumes != nil {
-		for containerPath, volumeMapping := range config.Volumes {
-			svc.WithVolume(volumeMapping.Name, containerPath, volumeMapping.IsLocal)
-		}
+		applyVolumesToService(svc, config.Volumes)
 	}
 	if config.DependsOn != nil {
 		applyDependsOn(svc, config.DependsOn, root)
@@ -574,6 +573,16 @@ func yamlReleaseToRelease(cfg *YAMLReleaseConfig) *release {
 }
 
 // applyFilesToService maps files to a service
+func applyVolumesToService(svc *Service, volumes map[string]*YAMLVolumeMappedConfig) {
+	for containerPath, volumeMapping := range volumes {
+		if volumeMapping.HostPath != "" {
+			svc.WithHostVolume(volumeMapping.HostPath, containerPath)
+		} else {
+			svc.WithVolume(volumeMapping.Name, containerPath, volumeMapping.IsLocal)
+		}
+	}
+}
+
 func applyFilesToService(svc *Service, files map[string]string) {
 	for containerPath, fileSource := range files {
 		var artifactName string
@@ -662,9 +671,7 @@ func createServiceFromConfig(name string, config *YAMLServiceConfig, root *Compo
 		applyFilesToService(svc, config.Files)
 	}
 	if config.Volumes != nil {
-		for containerPath, volumeMapping := range config.Volumes {
-			svc.WithVolume(volumeMapping.Name, containerPath, volumeMapping.IsLocal)
-		}
+		applyVolumesToService(svc, config.Volumes)
 	}
 	if config.DependsOn != nil {
 		applyDependsOn(svc, config.DependsOn, root)

--- a/playground/recipe_yaml_test.go
+++ b/playground/recipe_yaml_test.go
@@ -417,6 +417,22 @@ func TestCreateServiceFromConfig_WithVolumes(t *testing.T) {
 	require.Equal(t, "myvolume", svc.VolumesMapped["/data"].Name)
 }
 
+func TestCreateServiceFromConfig_WithHostPathVolume(t *testing.T) {
+	config := &YAMLServiceConfig{
+		Image: "test-image",
+		Volumes: map[string]*YAMLVolumeMappedConfig{"/var/run/docker.sock": {
+			HostPath: "/var/run/docker.sock",
+		}},
+	}
+
+	svc := createServiceFromConfig("my-service", config, nil, "")
+
+	require.NotNil(t, svc.VolumesMapped)
+	require.Equal(t, "/var/run/docker.sock", svc.VolumesMapped["/var/run/docker.sock"].HostPath)
+	require.Empty(t, svc.VolumesMapped["/var/run/docker.sock"].Name)
+	require.False(t, svc.VolumesMapped["/var/run/docker.sock"].IsLocal)
+}
+
 func TestParseYAMLRecipe(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "recipe-test")
 	require.NoError(t, err)


### PR DESCRIPTION
YAML recipes currently support named Docker volumes and session-local bind mounts, but not arbitrary host path bind mounts. This is needed for services that require access to host resources.

Concrete use case: log collections with docker socket, hot binary reload

- Add host_path field to volume config, enabling direct host-to-container bind mounts (e.g. /var/run/docker.sock)
- Existing volume types (name/is_local) are unchanged