### PR TITLE
fix(mac-os): tag extraction for latest release in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -31,7 +31,11 @@ if [ -n "${VERSION:-}" ]; then
   fi
 else
   echo "Fetching latest release..."
-  TAG=$(curl -sSfL "$API" | grep -oP '"tag_name": "\K(.*)(?=")')
+  TAG=$(curl -sSfL "$API" | sed -n 's/.*"tag_name":[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)
+  if [ -z "$TAG" ]; then
+    echo "Error: could not determine latest release tag"
+    exit 1
+  fi
   echo "Latest version: $TAG"
 fi
 


### PR DESCRIPTION
Running the suggested install command in mac os gives this error:

```
❯ curl -sSfL https://raw.githubusercontent.com/flashbots/builder-playground/main/install.sh | bash
Fetching latest release...
grep: invalid option -- P
usage: grep [-abcdDEFGHhIiJLlMmnOopqRSsUVvwXxZz] [-A num] [-B num] [-C[num]]
        [-e pattern] [-f file] [--binary-files=value] [--color=when]
        [--context[=num]] [--directories=action] [--label] [--line-buffered]
        [--null] [pattern] [file ...]
```

This PR addresses this problem by removing the `-P` problematic flag with `sed`. This will keep compatibility with linux too.