### PR TITLE
Keep playground process after detachment

### DIFF
--- a/main.go
+++ b/main.go
@@ -57,6 +57,7 @@ var (
 	contenderArgs         []string
 	contenderTarget       string
 	detached              bool
+	detachedNotifyFd      int
 	readyServer           bool
 	skipSetup             bool
 	prefundedAccounts     []string
@@ -601,6 +602,8 @@ func main() {
 		cmd.Flags().StringArrayVar(&contenderArgs, "contender.arg", []string{}, "add/override contender CLI flags")
 		cmd.Flags().StringVar(&contenderTarget, "contender.target", "", "override the node that contender spams")
 		cmd.Flags().BoolVar(&detached, "detached", false, "Detached mode: Run the recipes in the background")
+		cmd.Flags().IntVar(&detachedNotifyFd, "detached-notify-fd", 0, "internal: file descriptor used by a detached child to signal readiness to its parent")
+		_ = cmd.Flags().MarkHidden("detached-notify-fd")
 		cmd.Flags().BoolVar(&readyServer, "ready-server", false, "Start an HTTP server on 0.0.0.0:8123 that returns 200 OK when all services are healthy")
 		cmd.Flags().BoolVar(&skipSetup, "skip-setup", false, "Skip the setup commands defined in the YAML recipe")
 		cmd.Flags().StringArrayVar(&prefundedAccounts, "prefunded-accounts", []string{}, "Fund this account in addition to static prefunded accounts")
@@ -709,6 +712,14 @@ func runIt(recipe playground.Recipe) error {
 		return fmt.Errorf("failed to parse log level: %w", err)
 	}
 	logging.ConfigureSlog(logLevelFlag)
+
+	// Detached parent mode: re-exec ourselves as an attached child,
+	// wait until all services are healthy, then exit while leaving the
+	// child running in the background.
+	if detached && detachedNotifyFd == 0 {
+		return runDetachedParent()
+	}
+
 	sessionID := utils.GeneratePetName()
 
 	out, err := playground.NewOutput(sessionID, outputFlag)
@@ -910,8 +921,13 @@ func runIt(recipe playground.Recipe) error {
 		}
 	}
 
-	if detached {
-		return nil
+	// If we were re-exec'd as the detached child, signal readiness to the
+	// parent and redirect stdio to a log file so the parent can exit cleanly
+	// without the child continuing to write to the shared terminal.
+	if detachedNotifyFd > 0 {
+		if err := notifyDetachedReady(detachedNotifyFd, out.Dst()); err != nil {
+			return fmt.Errorf("failed to detach: %w", err)
+		}
 	}
 
 	watchdogErr := make(chan error, 1)
@@ -953,4 +969,34 @@ func runIt(recipe playground.Recipe) error {
 	}
 
 	return exitErr
+}
+
+// runDetachedParent re-execs the current binary as an attached child and waits
+// for it to signal that all services are healthy. Once the child signals
+// readiness, the parent detaches from it and exits; the child keeps running in
+// the background.
+func runDetachedParent() error {
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("failed to locate self executable: %w", err)
+	}
+
+	child, err := utils.DetachFork(utils.DetachForkOptions{
+		Executable: exe,
+		Args:       utils.StripFlag(os.Args[1:], "--detached", false),
+	})
+	if err != nil {
+		return err
+	}
+
+	slog.Info("Playground detached and running in background", "pid", child.PID)
+	return nil
+}
+
+// notifyDetachedReady is called by the re-exec'd child once all services are
+// healthy. It writes the ready marker to the parent's pipe and redirects the
+// child's stdio so the parent can exit without leaving the child writing to
+// the shared terminal.
+func notifyDetachedReady(fd int, sessionDir string) error {
+	return utils.NotifyDetachReady(fd, filepath.Join(sessionDir, "playground.log"))
 }

--- a/utils/detached.go
+++ b/utils/detached.go
@@ -1,0 +1,259 @@
+package utils
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strings"
+	"sync"
+	"syscall"
+)
+
+// ReadyMarker is the line a re-exec'd child writes to its notify fd to tell
+// its parent that startup is complete and it is safe to detach.
+const ReadyMarker = "READY"
+
+// DefaultNotifyFlag is the CLI flag used to pass the notify fd to a re-exec'd
+// child when DetachForkOptions.NotifyFlag is left empty.
+const DefaultNotifyFlag = "--detached-notify-fd"
+
+// detachedNotifyFd is the fd number the child sees the notify pipe on. It
+// matches ExtraFiles[0] semantics for exec.Cmd (fd 3 in the child).
+const detachedNotifyFd = 3
+
+// DetachForkOptions configures DetachFork.
+type DetachForkOptions struct {
+	// Executable is the binary to launch. Required.
+	Executable string
+
+	// Args are the CLI args passed to the child (not including argv[0]).
+	// Callers are responsible for stripping any flag that would cause the
+	// child to recurse back into parent-mode (e.g. --detached).
+	Args []string
+
+	// NotifyFlag is the flag appended to Args telling the child which fd
+	// carries the ready pipe. "=<fd>" is appended automatically. If empty,
+	// DefaultNotifyFlag is used.
+	NotifyFlag string
+
+	// Env is the environment passed to the child. If nil, the child inherits
+	// the current process's environment.
+	Env []string
+
+	// Stdout and Stderr are inherited by the child so the user sees startup
+	// logs live. Default to os.Stdout and os.Stderr.
+	Stdout *os.File
+	Stderr *os.File
+
+	// ForwardSignals lists signals forwarded to the child while the parent is
+	// waiting for readiness, so Ctrl-C during startup still tears things down
+	// cleanly. Defaults to SIGINT, SIGTERM, SIGHUP, SIGQUIT.
+	ForwardSignals []os.Signal
+}
+
+// DetachedChild is the handle returned once the child has signaled readiness.
+// The parent has already released the process (no reaping required) and can
+// exit freely; the child keeps running in its own session.
+type DetachedChild struct {
+	PID int
+}
+
+// DetachFork re-execs Executable as a child process, attaches a one-shot
+// readiness pipe to fd 3 in the child, and blocks until the child writes
+// ReadyMarker to that pipe. On success the child is released and the returned
+// DetachedChild reports its PID. If the child exits or closes the pipe before
+// signaling ready, an error is returned.
+func DetachFork(opts DetachForkOptions) (*DetachedChild, error) {
+	if opts.Executable == "" {
+		return nil, fmt.Errorf("detach: Executable is required")
+	}
+	notifyFlag := opts.NotifyFlag
+	if notifyFlag == "" {
+		notifyFlag = DefaultNotifyFlag
+	}
+	stdout := opts.Stdout
+	if stdout == nil {
+		stdout = os.Stdout
+	}
+	stderr := opts.Stderr
+	if stderr == nil {
+		stderr = os.Stderr
+	}
+	signals := opts.ForwardSignals
+	if len(signals) == 0 {
+		signals = []os.Signal{syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP, syscall.SIGQUIT}
+	}
+
+	readyR, readyW, err := os.Pipe()
+	if err != nil {
+		return nil, fmt.Errorf("detach: pipe: %w", err)
+	}
+	defer readyR.Close()
+
+	args := append([]string{}, opts.Args...)
+	args = append(args, fmt.Sprintf("%s=%d", notifyFlag, detachedNotifyFd))
+
+	cmd := exec.Command(opts.Executable, args...)
+	cmd.Stdin = nil
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	cmd.ExtraFiles = []*os.File{readyW}
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if opts.Env != nil {
+		cmd.Env = opts.Env
+	}
+
+	if err := cmd.Start(); err != nil {
+		readyW.Close()
+		return nil, fmt.Errorf("detach: start child: %w", err)
+	}
+	// Close the parent's copy of the write end so the reader hits EOF if the
+	// child exits without writing the ready marker.
+	readyW.Close()
+
+	stopForward := forwardSignalsTo(cmd.Process, signals)
+	defer stopForward()
+
+	if err := waitForReady(readyR); err != nil {
+		waitErr := cmd.Wait()
+		if waitErr != nil {
+			return nil, fmt.Errorf("detach: child exited before ready: %w", waitErr)
+		}
+		return nil, fmt.Errorf("detach: %w", err)
+	}
+
+	// Capture the PID before Release — on unix, Release sets Pid to -1 to
+	// mark the handle unusable.
+	pid := cmd.Process.Pid
+	if err := cmd.Process.Release(); err != nil {
+		return nil, fmt.Errorf("detach: release child: %w", err)
+	}
+
+	return &DetachedChild{PID: pid}, nil
+}
+
+// StripFlag returns args with any occurrence of --flag, --flag=value, or the
+// two-token form --flag value removed. It is intended for trimming a parent
+// mode flag (e.g. --detached) out of os.Args before handing them to a child
+// via DetachFork.
+func StripFlag(args []string, flag string, takesValue bool) []string {
+	prefix := flag + "="
+	out := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if a == flag {
+			if takesValue && i+1 < len(args) {
+				i++
+			}
+			continue
+		}
+		if strings.HasPrefix(a, prefix) {
+			continue
+		}
+		out = append(out, a)
+	}
+	return out
+}
+
+// SignalReady writes ReadyMarker (followed by a newline) to fd and closes it.
+// The fd must be a writable pipe whose read end is held by the parent. After
+// this call the caller must not use fd again.
+func SignalReady(fd int) error {
+	notify := os.NewFile(uintptr(fd), "detached-notify")
+	if notify == nil {
+		return fmt.Errorf("detach: invalid notify fd: %d", fd)
+	}
+	if _, err := notify.Write([]byte(ReadyMarker + "\n")); err != nil {
+		notify.Close()
+		return fmt.Errorf("detach: write ready: %w", err)
+	}
+	if err := notify.Close(); err != nil {
+		return fmt.Errorf("detach: close notify fd: %w", err)
+	}
+	return nil
+}
+
+// RedirectStdio points the current process's stdin at /dev/null and stdout and
+// stderr at logPath (opened in append mode, creating it if needed). If logPath
+// is empty, stdout and stderr are redirected to /dev/null as well. Existing
+// file descriptors for stdout/stderr are atomically replaced via dup2, so
+// Go code that captured os.Stdout/os.Stderr before the call continues to
+// write to the redirected target.
+func RedirectStdio(logPath string) error {
+	var out *os.File
+	if logPath != "" {
+		f, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+		if err != nil {
+			return fmt.Errorf("detach: open %s: %w", logPath, err)
+		}
+		out = f
+	} else {
+		f, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+		if err != nil {
+			return fmt.Errorf("detach: open %s: %w", os.DevNull, err)
+		}
+		out = f
+	}
+	defer out.Close()
+
+	if err := syscall.Dup2(int(out.Fd()), int(os.Stdout.Fd())); err != nil {
+		return fmt.Errorf("detach: redirect stdout: %w", err)
+	}
+	if err := syscall.Dup2(int(out.Fd()), int(os.Stderr.Fd())); err != nil {
+		return fmt.Errorf("detach: redirect stderr: %w", err)
+	}
+	if devNull, err := os.OpenFile(os.DevNull, os.O_RDONLY, 0); err == nil {
+		_ = syscall.Dup2(int(devNull.Fd()), int(os.Stdin.Fd()))
+		devNull.Close()
+	}
+	return nil
+}
+
+// NotifyDetachReady is a convenience that calls SignalReady followed by
+// RedirectStdio — the full sequence a re-exec'd child performs once it has
+// finished bringing its services up.
+func NotifyDetachReady(fd int, logPath string) error {
+	if err := SignalReady(fd); err != nil {
+		return err
+	}
+	return RedirectStdio(logPath)
+}
+
+func forwardSignalsTo(proc *os.Process, signals []os.Signal) func() {
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, signals...)
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case s := <-sigCh:
+				_ = proc.Signal(s)
+			case <-stop:
+				return
+			}
+		}
+	}()
+	return func() {
+		signal.Stop(sigCh)
+		close(stop)
+		wg.Wait()
+	}
+}
+
+func waitForReady(r *os.File) error {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		if strings.TrimSpace(scanner.Text()) == ReadyMarker {
+			return nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("read ready pipe: %w", err)
+	}
+	return fmt.Errorf("child closed pipe without signaling %q", ReadyMarker)
+}

--- a/utils/detached_test.go
+++ b/utils/detached_test.go
@@ -1,0 +1,308 @@
+package utils
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Test helper protocol: when DETACH_TEST_HELPER is set, TestMain dispatches to
+// a stand-in "child" binary instead of running the test suite. The re-exec'd
+// child then exercises the library from the other side of the pipe. This is
+// the standard trick Go's os/exec tests use to avoid needing a separate binary.
+const (
+	helperEnv       = "DETACH_TEST_HELPER"
+	helperLogPath   = "DETACH_TEST_LOG_PATH"
+	helperPostWrite = "DETACH_TEST_POST_WRITE"
+)
+
+func TestMain(m *testing.M) {
+	if mode := os.Getenv(helperEnv); mode != "" {
+		runHelper(mode)
+		return
+	}
+	os.Exit(m.Run())
+}
+
+func runHelper(mode string) {
+	switch mode {
+	case "signal-ready":
+		if err := SignalReady(detachedNotifyFd); err != nil {
+			fmt.Fprintln(os.Stderr, "signal-ready:", err)
+			os.Exit(2)
+		}
+		// Linger briefly so the parent has time to observe READY before we exit
+		// and (on some kernels) before our writes to the pipe are discarded.
+		time.Sleep(200 * time.Millisecond)
+		os.Exit(0)
+
+	case "notify-then-write":
+		logPath := os.Getenv(helperLogPath)
+		post := os.Getenv(helperPostWrite)
+		if err := NotifyDetachReady(detachedNotifyFd, logPath); err != nil {
+			os.Exit(3)
+		}
+		// After NotifyDetachReady, stdout/stderr point at logPath.
+		fmt.Println(post)
+		os.Exit(0)
+
+	case "exit-without-ready":
+		// Intentionally exit without touching fd 3.
+		os.Exit(7)
+
+	case "garbage-then-exit":
+		f := os.NewFile(detachedNotifyFd, "notify")
+		_, _ = f.Write([]byte("NOPE\n"))
+		f.Close()
+		os.Exit(8)
+
+	default:
+		fmt.Fprintln(os.Stderr, "unknown helper mode:", mode)
+		os.Exit(99)
+	}
+}
+
+func selfExe(t *testing.T) string {
+	t.Helper()
+	exe, err := os.Executable()
+	require.NoError(t, err)
+	return exe
+}
+
+func envWith(extra ...string) []string {
+	env := append([]string{}, os.Environ()...)
+	return append(env, extra...)
+}
+
+func TestStripFlag(t *testing.T) {
+	cases := []struct {
+		name       string
+		args       []string
+		flag       string
+		takesValue bool
+		want       []string
+	}{
+		{
+			name: "bare flag removed",
+			args: []string{"start", "l1", "--detached", "--keep"},
+			flag: "--detached",
+			want: []string{"start", "l1", "--keep"},
+		},
+		{
+			name: "equals form removed",
+			args: []string{"start", "l1", "--detached=true", "--keep"},
+			flag: "--detached",
+			want: []string{"start", "l1", "--keep"},
+		},
+		{
+			name:       "two-token value consumed",
+			args:       []string{"start", "--log-level", "debug", "--detached"},
+			flag:       "--log-level",
+			takesValue: true,
+			want:       []string{"start", "--detached"},
+		},
+		{
+			name: "flag not present is a no-op",
+			args: []string{"start", "l1", "--keep"},
+			flag: "--detached",
+			want: []string{"start", "l1", "--keep"},
+		},
+		{
+			name: "only the target flag is affected",
+			args: []string{"--detached-notify-fd=3", "--detached", "--keep"},
+			flag: "--detached",
+			want: []string{"--detached-notify-fd=3", "--keep"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := StripFlag(tc.args, tc.flag, tc.takesValue)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestSignalReady(t *testing.T) {
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	t.Cleanup(func() { r.Close() })
+
+	// Pass a dup'd fd so our own w remains valid for cleanup regardless of
+	// SignalReady's internal Close.
+	dupFd, err := syscall.Dup(int(w.Fd()))
+	require.NoError(t, err)
+
+	require.NoError(t, SignalReady(dupFd))
+
+	// Close our copy so the read end observes EOF after the ready line.
+	w.Close()
+
+	buf, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.Equal(t, ReadyMarker+"\n", string(buf))
+}
+
+func TestSignalReady_InvalidFd(t *testing.T) {
+	// A fd we know is closed — SignalReady should propagate the write error.
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	r.Close()
+	fd := int(w.Fd())
+	w.Close()
+	err = SignalReady(fd)
+	require.Error(t, err)
+}
+
+func TestDetachFork_HappyPath(t *testing.T) {
+	exe := selfExe(t)
+
+	child, err := DetachFork(DetachForkOptions{
+		Executable: exe,
+		Args:       []string{"-test.run=^$"},
+		Env:        envWith(helperEnv + "=signal-ready"),
+		Stdout:     devNull(t),
+		Stderr:     devNull(t),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, child)
+	require.Greater(t, child.PID, 0)
+
+	// Best-effort reap so we don't leave orphans behind after the test.
+	waitForPid(t, child.PID, 3*time.Second)
+}
+
+func TestDetachFork_ChildExitsBeforeReady(t *testing.T) {
+	exe := selfExe(t)
+
+	child, err := DetachFork(DetachForkOptions{
+		Executable: exe,
+		Args:       []string{"-test.run=^$"},
+		Env:        envWith(helperEnv + "=exit-without-ready"),
+		Stdout:     devNull(t),
+		Stderr:     devNull(t),
+	})
+	require.Error(t, err)
+	require.Nil(t, child)
+	require.Contains(t, err.Error(), "before ready")
+}
+
+func TestDetachFork_ChildClosesPipeWithoutReady(t *testing.T) {
+	exe := selfExe(t)
+
+	child, err := DetachFork(DetachForkOptions{
+		Executable: exe,
+		Args:       []string{"-test.run=^$"},
+		Env:        envWith(helperEnv + "=garbage-then-exit"),
+		Stdout:     devNull(t),
+		Stderr:     devNull(t),
+	})
+	require.Error(t, err)
+	require.Nil(t, child)
+}
+
+func TestDetachFork_PassesArgsThroughAndAppendsNotifyFlag(t *testing.T) {
+	// This test verifies end-to-end that Args make it to the child and that
+	// the notify flag is understood on fd 3. The helper doesn't parse args,
+	// but it does read from fd 3 — which is only present if DetachFork wired
+	// the ExtraFiles correctly.
+	exe := selfExe(t)
+
+	child, err := DetachFork(DetachForkOptions{
+		Executable: exe,
+		Args:       []string{"-test.run=^$", "--extra-arg", "value"},
+		Env:        envWith(helperEnv + "=signal-ready"),
+		Stdout:     devNull(t),
+		Stderr:     devNull(t),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, child)
+	waitForPid(t, child.PID, 3*time.Second)
+}
+
+func TestNotifyDetachReady_WritesPostReadyOutputToLogFile(t *testing.T) {
+	tmp := t.TempDir()
+	logPath := filepath.Join(tmp, "child.log")
+	exe := selfExe(t)
+
+	child, err := DetachFork(DetachForkOptions{
+		Executable: exe,
+		Args:       []string{"-test.run=^$"},
+		Env: envWith(
+			helperEnv+"=notify-then-write",
+			helperLogPath+"="+logPath,
+			helperPostWrite+"=hello-from-detached-child",
+		),
+		Stdout: devNull(t),
+		Stderr: devNull(t),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, child)
+
+	// The child writes to the log file AFTER signaling ready, so we need to
+	// wait for it to actually happen before asserting on file contents.
+	require.Eventually(t, func() bool {
+		b, err := os.ReadFile(logPath)
+		if err != nil {
+			return false
+		}
+		return string(b) == "hello-from-detached-child\n"
+	}, 5*time.Second, 25*time.Millisecond, "log file never received post-ready output")
+
+	waitForPid(t, child.PID, 3*time.Second)
+}
+
+func TestRedirectStdio_DevNullWhenEmptyPath(t *testing.T) {
+	// RedirectStdio mutates the test process's own stdio, which would break
+	// subsequent test output. Run it in a subprocess and just assert the
+	// helper exited cleanly.
+	exe := selfExe(t)
+
+	child, err := DetachFork(DetachForkOptions{
+		Executable: exe,
+		Args:       []string{"-test.run=^$"},
+		// Empty DETACH_TEST_LOG_PATH → RedirectStdio falls back to /dev/null.
+		Env: envWith(
+			helperEnv+"=notify-then-write",
+			helperLogPath+"=",
+			helperPostWrite+"=to-devnull",
+		),
+		Stdout: devNull(t),
+		Stderr: devNull(t),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, child)
+	waitForPid(t, child.PID, 3*time.Second)
+}
+
+// devNull returns an *os.File handle to /dev/null owned by the test; it is
+// closed on cleanup. Useful for silencing children's inherited stdio.
+func devNull(t *testing.T) *os.File {
+	t.Helper()
+	f, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	require.NoError(t, err)
+	t.Cleanup(func() { f.Close() })
+	return f
+}
+
+// waitForPid polls until the given pid has exited or timeout elapses. We can't
+// Wait() on the child directly because DetachFork called Release() and
+// Setsid'd it into a new session.
+func waitForPid(t *testing.T, pid int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(pid, 0); err != nil {
+			return // process gone
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	// If still alive, try to clean it up. Not fatal — the helper has a short
+	// self-lifetime anyway — but leaves the process table tidy.
+	_ = syscall.Kill(pid, syscall.SIGKILL)
+}


### PR DESCRIPTION
This makes playground stop/clean all resources when the `stop`/`clean` commands are used and avoid orphan processes.

Fixes #377 