### PR TITLE
Fix --block-time flag being ignored due to SlotDurationMilliseconds precedence

### DIFF
--- a/playground/artifacts.go
+++ b/playground/artifacts.go
@@ -244,6 +244,10 @@ func (b *ArtifactsBuilder) Build(out *output) error {
 	if err != nil {
 		return err
 	}
+	// UnmarshalConfig starts from mainnet defaults which has SlotDurationMilliseconds=12000.
+	// Since SlotDurationMillis() prefers SlotDurationMilliseconds over SecondsPerSlot when > 0,
+	// we must sync it with the desired block time or the configured SecondsPerSlot is ignored.
+	clConfig.SlotDurationMilliseconds = b.l1BlockTimeInSeconds * 1000
 	if err := params.SetActive(clConfig); err != nil {
 		return err
 	}


### PR DESCRIPTION
Prysm v7 introduced SlotDurationMilliseconds which takes precedence over SecondsPerSlot when > 0. UnmarshalConfig seeds from MainnetConfig() which has SlotDurationMilliseconds=12000, so setting SECONDS_PER_SLOT: 1 in the template had no effect — the slot duration stayed at 12s. Explicitly sync SlotDurationMilliseconds after UnmarshalConfig so the configured block time is actually applied.

A different way to fix it would be to change the CL config template that currently has `SECONDS_PER_SLOT` to use `SLOT_DURATION_MS` instead (and use Golang template to render it instead of hard-coded manual replacement)